### PR TITLE
Bind this to server instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Injects a fake request into an HTTP server.
     - `error` - whether the request will emit an `error` event. Defaults to `undefined`, meaning no `error` event will be emitted. If set to `true`, the emitted error will have a message of `'Simulated'`.
     - `close` - whether the request will emit a `close` event. Defaults to `undefined`, meaning no `close` event will be emitted.
   - `validate` - Optional flag to validate this options object. Defaults to `true`.
+  - `server` - Optional http server. It is used for binding the `dispatchFunc`.
 - `callback` - the callback function using the signature `function (res)` where:
   - `res` - a response object where:
     - `raw` - an object containing the raw request and response objects where:

--- a/index.js
+++ b/index.js
@@ -62,17 +62,19 @@ function inject (dispatchFunc, options, callback) {
     }
   }
 
+  const that = options.server || {}
+
   if (typeof callback === 'function') {
     const req = new Request(options)
     const res = new Response(req, callback)
 
-    return req.prepare(() => dispatchFunc(req, res))
+    return req.prepare(() => dispatchFunc.call(that, req, res))
   } else {
     return new Promise((resolve) => {
       const req = new Request(options)
       const res = new Response(req, resolve)
 
-      req.prepare(() => dispatchFunc(req, res))
+      req.prepare(() => dispatchFunc.call(that, req, res))
     })
   }
 }

--- a/index.js
+++ b/index.js
@@ -62,19 +62,19 @@ function inject (dispatchFunc, options, callback) {
     }
   }
 
-  const that = options.server || {}
+  const server = options.server || {}
 
   if (typeof callback === 'function') {
     const req = new Request(options)
     const res = new Response(req, callback)
 
-    return req.prepare(() => dispatchFunc.call(that, req, res))
+    return req.prepare(() => dispatchFunc.call(server, req, res))
   } else {
     return new Promise((resolve) => {
       const req = new Request(options)
       const res = new Response(req, resolve)
 
-      req.prepare(() => dispatchFunc.call(that, req, res))
+      req.prepare(() => dispatchFunc.call(server, req, res))
     })
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ajv": "^5.2.3"
   },
   "devDependencies": {
+    "pre-commit": "^1.2.2",
     "standard": "^10.0.3",
     "tap": "^10.7.2"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,7 @@ const Stream = require('stream')
 const fs = require('fs')
 const zlib = require('zlib')
 const inject = require('../index')
+const http = require('http')
 
 test('returns non-chunked payload', (t) => {
   t.plan(6)
@@ -687,6 +688,20 @@ test('async wait support', t => {
     t.pass('Skip because Node version < 8')
     t.end()
   }
+})
+
+test('this should be the server instance', t => {
+  t.plan(2)
+
+  const server = http.createServer()
+
+  const dispatch = function (req, res) {
+    t.equal(this, server)
+    res.end('hello')
+  }
+
+  inject(dispatch, { method: 'get', url: 'http://example.com:8080/hello', server: server })
+    .then(res => t.equal(res.statusCode, 200))
 })
 
 function getTestStream (encoding) {


### PR DESCRIPTION
Bind this to http server instance

The right behaviour calling the handler to the `request` event. All events are fired binding `this` to the event emitter.