### PR TITLE
Use safe-buffer for Node 4 compatibility (fix #8)

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const Stream = require('stream')
 const Url = require('url')
 const util = require('util')

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const http = require('http')
 const Stream = require('stream')
 const util = require('util')

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Fake HTTP injection library",
   "main": "index.js",
   "dependencies": {
-    "ajv": "^5.2.3"
+    "ajv": "^5.2.3",
+    "safe-buffer": "^5.1.1"
   },
   "devDependencies": {
     "pre-commit": "^1.2.2",


### PR DESCRIPTION
As long as Fastify intends to support Node 4 then this needs to use the `safe-buffer` module.