### PR TITLE
Remove `readable-stream`.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -2,7 +2,7 @@
 
 const Buffer = require('safe-buffer').Buffer
 const http = require('http')
-const stream = require('readable-stream')
+const stream = require('stream')
 const util = require('util')
 
 function Response (req, onEnd, reject) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "dependencies": {
     "ajv": "^6.0.0",
-    "readable-stream": "^2.3.3",
     "safe-buffer": "^5.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`lib/request.js` uses `stream`, while `lib/response.js` uses `readable-stream`.  Unless I'm missing something, it should probably be one way or the other.