### PR TITLE
Force stream resume

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -84,7 +84,7 @@ Request.prototype.prepare = function (next) {
     return next()
   })
 
-  // Force to resume the stream. Need for stream1
+  // Force to resume the stream. Needed for Stream 1
   this._lightMyRequest.payload.resume()
 }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -84,6 +84,7 @@ Request.prototype.prepare = function (next) {
     return next()
   })
 
+  // Force to resume the stream. Need for stream1
   this._lightMyRequest.payload.resume()
 }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -83,6 +83,8 @@ Request.prototype.prepare = function (next) {
     this._lightMyRequest.payload = payload
     return next()
   })
+
+  this._lightMyRequest.payload.resume()
 }
 
 Request.prototype._read = function (size) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "safe-buffer": "^5.1.1"
   },
   "devDependencies": {
+    "form-data": "^2.3.2",
     "pre-commit": "^1.2.2",
     "standard": "^11.0.0",
     "tap": "^12.0.0"

--- a/test/test.js
+++ b/test/test.js
@@ -813,7 +813,6 @@ test('form-data should be handled correctly', (t) => {
   }
 
   const form = new FormData()
-  form._boundary = 'the-boundary'
   form.append('my_field', 'my value')
 
   inject(dispatch, {
@@ -823,7 +822,7 @@ test('form-data should be handled correctly', (t) => {
   }, (err, res) => {
     t.error(err)
     t.equal(res.statusCode, 200)
-    t.equal(res.payload, '--the-boundary\r\nContent-Disposition: form-data; name="my_field"\r\n\r\nmy value\r\n--the-boundary--\r\n')
+    t.ok(/--.+\r\nContent-Disposition: form-data; name="my_field"\r\n\r\nmy value\r\n--.+--\r\n/.test(res.payload))
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -797,6 +797,35 @@ test('HTTP method is case insensitive', (t) => {
   })
 })
 
+const FormData = require('form-data')
+test('form-data should be handled correctly', (t) => {
+  t.plan(3)
+
+  const dispatch = function (req, res) {
+    let body = ''
+    req.on('data', d => {
+      body += d
+    })
+    req.on('end', () => {
+      res.end(body)
+    })
+  }
+
+  const form = new FormData()
+  form._boundary = 'the-boundary'
+  form.append('my_field', 'my value')
+
+  inject(dispatch, {
+    method: 'POST',
+    url: 'http://example.com:8080/hello',
+    payload: form
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(res.payload, '--the-boundary\r\nContent-Disposition: form-data; name="my_field"\r\n\r\nmy value\r\n--the-boundary--\r\n')
+  })
+})
+
 function getTestStream (encoding) {
   const Read = function () {
     Stream.Readable.call(this)

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,8 @@ const zlib = require('zlib')
 const inject = require('../index')
 const http = require('http')
 
+const FormData = require('form-data')
+
 test('returns non-chunked payload', (t) => {
   t.plan(7)
   const output = 'example.com:8080|/hello'
@@ -797,7 +799,6 @@ test('HTTP method is case insensitive', (t) => {
   })
 })
 
-const FormData = require('form-data')
 test('form-data should be handled correctly', (t) => {
   t.plan(3)
 


### PR DESCRIPTION
As titled, if the payload is a stream, `light-my-request` should force its resume.

Fix https://github.com/fastify/fastify/pull/1026