### PR TITLE
Adds support for readable-stream@3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 
 node_js:
-  - "9"
   - "8"
   - "6"
-  - "4"
   - "10"
 
 notifications:

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const Buffer = require('safe-buffer').Buffer
-const Stream = require('stream')
+const { Readable } = require('readable-stream')
 const Url = require('url')
 const util = require('util')
 
 function Request (options) {
-  Stream.Readable.call(this)
+  Readable.call(this)
   // options: method, url, payload, headers, remoteAddress
   var url = options.url
   if (typeof url === 'object') {
@@ -46,13 +45,13 @@ function Request (options) {
   }
 
   var payload = options.payload || null
-  if (payload && typeof payload !== 'string' && !(payload instanceof Stream) && !Buffer.isBuffer(payload)) {
+  if (payload && typeof payload !== 'string' && !(typeof payload.resume === 'function') && !Buffer.isBuffer(payload)) {
     payload = JSON.stringify(payload)
     this.headers['content-type'] = this.headers['content-type'] || 'application/json'
   }
 
   // Set the content-length for the corresponding payload if none set
-  if (payload && !(payload instanceof Stream) && !this.headers.hasOwnProperty('content-length')) {
+  if (payload && !(typeof payload.resume === 'function') && !this.headers.hasOwnProperty('content-length')) {
     this.headers['content-length'] = (Buffer.isBuffer(payload) ? payload.length : Buffer.byteLength(payload)).toString()
   }
 
@@ -66,18 +65,19 @@ function Request (options) {
   return this
 }
 
-util.inherits(Request, Stream.Readable)
+util.inherits(Request, Readable)
 
 Request.prototype.prepare = function (next) {
-  if (this._lightMyRequest.payload instanceof Stream === false) {
+  const payload = this._lightMyRequest.payload
+  if (!payload || typeof payload.resume !== 'function') { // does not quack like a stream
     return next()
   }
 
   const chunks = []
 
-  this._lightMyRequest.payload.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+  payload.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
 
-  this._lightMyRequest.payload.on('end', () => {
+  payload.on('end', () => {
     const payload = Buffer.concat(chunks)
     this.headers['content-length'] = this.headers['content-length'] || ('' + payload.length)
     this._lightMyRequest.payload = payload
@@ -85,7 +85,7 @@ Request.prototype.prepare = function (next) {
   })
 
   // Force to resume the stream. Needed for Stream 1
-  this._lightMyRequest.payload.resume()
+  payload.resume()
 }
 
 Request.prototype._read = function (size) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,8 +1,7 @@
 'use strict'
 
-const Buffer = require('safe-buffer').Buffer
 const http = require('http')
-const stream = require('readable-stream')
+const { Writable } = require('readable-stream')
 const util = require('util')
 
 function Response (req, onEnd, reject) {
@@ -110,7 +109,7 @@ function generatePayload (response) {
 
 // Throws away all written data to prevent response from buffering payload
 function getNullSocket () {
-  return new stream.Writable({
+  return new Writable({
     write (chunk, encoding, callback) {
       setImmediate(callback)
     }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "ajv": "^6.0.0",
-    "readable-stream": "^2.3.6",
-    "safe-buffer": "^5.1.2"
+    "readable-stream": "^3.0.0"
   },
   "devDependencies": {
     "form-data": "^2.3.2",

--- a/test/test.js
+++ b/test/test.js
@@ -2,8 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const util = require('util')
-const Stream = require('stream')
+const { Readable } = require('readable-stream')
 const fs = require('fs')
 const zlib = require('zlib')
 const inject = require('../index')
@@ -354,7 +353,7 @@ test('pipes response with old stream', (t) => {
     res.writeHead(200)
     const stream = getTestStream()
     stream.pause()
-    const stream2 = new Stream.Readable().wrap(stream)
+    const stream2 = new Readable().wrap(stream)
     stream.resume()
 
     res.on('finish', () => {
@@ -827,20 +826,14 @@ test('form-data should be handled correctly', (t) => {
 })
 
 function getTestStream (encoding) {
-  const Read = function () {
-    Stream.Readable.call(this)
-  }
-
-  util.inherits(Read, Stream.Readable)
-
   const word = 'hi'
   let i = 0
 
-  Read.prototype._read = function (size) {
-    this.push(word[i] ? word[i++] : null)
-  }
-
-  const stream = new Read()
+  const stream = new Readable({
+    read (n) {
+      this.push(word[i] ? word[i++] : null)
+    }
+  })
 
   if (encoding) {
     stream.setEncoding(encoding)


### PR DESCRIPTION
It also adds support for faux streams and relies on duck typing.
Removes support for Node 4, 5, 7 and 9.
Removes support for safe-buffer as it's not needed anymore.

This will be a semver-major change for light-my-request (dropped old nodes support), but we can drop it in fastify as a minor (not breaking for them).