### PR TITLE
Added body -> payload aliases tog match the rest of Fastify APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Injects a fake request into an HTTP server.
   - `headers` - an optional object containing request headers.
   - `remoteAddress` - an optional string specifying the client remote address. Defaults to `'127.0.0.1'`.
   - `payload` - an optional request payload. Can be a string, Buffer, Stream or object.
+  - `body` - alias for payload.
   - `simulate` - an object containing flags to simulate various conditions:
     - `end` - indicates whether the request will fire an `end` event. Defaults to `undefined`, meaning an `end` event will fire.
     - `split` - indicates whether the request payload will be split into chunks. Defaults to `undefined`, meaning payload will not be chunked.
@@ -77,6 +78,7 @@ Injects a fake request into an HTTP server.
     - `statusCode` - the HTTP status code.
     - `statusMessage` - the HTTP status message.
     - `payload` - the payload as a UTF-8 encoded string.
+    - `body` - alias for payload.
     - `rawPayload` - the raw payload as a Buffer.
     - `trailers` - an object containing the response trailers.
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -44,7 +44,8 @@ function Request (options) {
     remoteAddress: options.remoteAddress || '127.0.0.1'
   }
 
-  var payload = options.payload || null
+  // we keep both payload and body for compatibility reasons
+  var payload = options.payload || options.body || null
   if (payload && typeof payload !== 'string' && !(typeof payload.resume === 'function') && !Buffer.isBuffer(payload)) {
     payload = JSON.stringify(payload)
     this.headers['content-type'] = this.headers['content-type'] || 'application/json'

--- a/lib/response.js
+++ b/lib/response.js
@@ -101,7 +101,10 @@ function generatePayload (response) {
   // Prepare payload and trailers
   const rawBuffer = Buffer.concat(response._lightMyRequest.payloadChunks)
   res.rawPayload = rawBuffer
+
+  // we keep both of them for compatibility reasons
   res.payload = rawBuffer.toString()
+  res.body = res.payload
   res.trailers = response._lightMyRequest.trailers
 
   return res

--- a/test/test.js
+++ b/test/test.js
@@ -384,6 +384,20 @@ test('echos object payload', (t) => {
   })
 })
 
+test('supports body option in Request and property in Response', (t) => {
+  t.plan(3)
+  const dispatch = function (req, res) {
+    res.writeHead(200, { 'content-type': req.headers['content-type'] })
+    req.pipe(res)
+  }
+
+  inject(dispatch, { method: 'POST', url: '/test', body: { a: 1 } }, (err, res) => {
+    t.error(err)
+    t.equal(res.headers['content-type'], 'application/json')
+    t.equal(res.body, '{"a":1}')
+  })
+})
+
 test('echos buffer payload', (t) => {
   t.plan(2)
   const dispatch = function (req, res) {


### PR DESCRIPTION
In the rest for the Fastify API, we use the term body to identify the body of a request.
Here is called payload. I find that extremely confusing.