### PR TITLE
Add TypeScript typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,42 @@ try {
 }
 ```
 
+This module ships with a handwritten TypeScript declaration file for TS support. The declaration exports a single namespace `LightMyRequest`. You can import it one of two ways:
+```typescript
+import * as LightMyRequest from 'light-my-request'
+
+const dispatch: LightMyRequest.DispatchFunc = function (req, res) {
+  const reply = 'Hello World'
+  res.writeHead(200, { 'Content-Type': 'text/plain', 'Content-Length': reply.length })
+  res.end(reply)
+}
+
+LightMyRequest.inject(dispatch, { method: 'get', url: '/' }, (err, res) => {
+  console.log(res.payload)
+})
+
+// or
+import { inject, DistpatchFunc } from 'light-my-request'
+
+const dispatch: DispatchFunc = function (req, res) {
+  const reply = 'Hello World'
+  res.writeHead(200, { 'Content-Type': 'text/plain', 'Content-Length': reply.length })
+  res.end(reply)
+}
+
+inject(dispatch, { method: 'get', url: '/' }, (err, res) => {
+  console.log(res.payload)
+})
+```
+The declaration file exports types for the following parts of the API:
+- `inject` - standard light-my-request `inject` method
+- `DispatchFunc` - the fake HTTP dispatch function
+- `InjectPayload` - a union type for valid payload types
+- `isInjection` - standard light-my-request `isInjection` method
+- `InjectOptions` - options object for `inject` method
+- `Request` - custom light-my-request `request` object interface. Extends Node.js `stream.Readable` type
+- `Response` - custom light-my-re uest `response` object interface. Extends Node.js `http.ServerResponse` type
+
 ## API
 
 #### `inject(dispatchFunc, options, callback)`

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,28 @@
 import * as stream from 'stream'
 import * as http from 'http'
 
-type HTTPMethods = 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS'
+type HTTPMethods = 'DELETE' | 'delete' |
+                   'GET' | 'get' |
+                   'HEAD' | 'head' |
+                   'PATCH' | 'patch' |
+                   'POST' | 'post' |
+                   'PUT' | 'put' |
+                   'OPTIONS' | 'options'
 
 declare namespace LightMyRequest {
-
-  type inject<Payload> = (
-    dispatchFunc: (req: Request, res: Response) => void,
+  function inject (
+    dispatchFunc: DispatchFunc,
+    options: string | InjectOptions
+  ): Promise<Response>
+  function inject (
+    dispatchFunc: DispatchFunc,
     options: string | InjectOptions,
-    callback: (err: Error, payload: any) => void | Promise<Payload>
-  ) => void
+    callback: (err: Error, response: Response) => void
+  ): void
+
+  type DispatchFunc = (req: Request, res: Response) => void
+
+  type InjectPayload = string | object | Buffer | NodeJS.ReadableStream
 
   function isInjection (obj: Request | Response): boolean
 
@@ -18,11 +31,11 @@ declare namespace LightMyRequest {
       pathname: string
       protocal?: string
       hostname?: string
-      port?: any
-      query?: any
+      port?: string | number
+      query?: string
     }
     headers?: http.IncomingHttpHeaders | http.OutgoingHttpHeaders
-    query?: any
+    query?: string
     simulate?: {
       end: boolean,
       split: boolean,
@@ -33,38 +46,29 @@ declare namespace LightMyRequest {
     remoteAddress?: string
     method?: HTTPMethods
     validate?: boolean
-    payload?: any
+    payload?: InjectPayload
     server?: http.Server
   }
 
-  interface Request<Payload = string> extends stream.Readable {
+  interface Request extends stream.Readable {
     url: string
     httpVersion: string
     method: HTTPMethods
     headers: http.IncomingHttpHeaders
-    connection: string
-    _lightMyRequest: {
-      payload: Payload
-      isDone: boolean,
-      simulate: {
-        end: boolean,
-        split: boolean,
-        error: boolean,
-        close: boolean
-      }
-    }
     prepare: (next: () => void) => void
-    _read: () => void
   }
 
   interface Response extends http.ServerResponse {
-    _lightMyRequest: {
-      headers: http.OutgoingHttpHeaders,
-      trailers: { [key: string]: string },
-      payloadChunks: Array<Buffer>
+    raw: {
+      res: http.ServerResponse
     }
-    _headers: http.OutgoingHttpHeaders
-    _promiseCallback: boolean
+    rawPayload: Buffer
+    headers: http.OutgoingHttpHeaders
+    statusCode: number
+    statusMessage: string
+    trailers: { [key: string]: string }
+    payload: string
+    body: string
     addTrailers: (trailers: { [key: string]: string }) => void
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,72 @@
+import * as stream from 'stream'
+import * as http from 'http'
+
+type HTTPMethods = 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'OPTIONS'
+
+declare namespace LightMyRequest {
+
+  type inject<Payload> = (
+    dispatchFunc: (req: Request, res: Response) => void,
+    options: string | InjectOptions,
+    callback: (err: Error, payload: any) => void | Promise<Payload>
+  ) => void
+
+  function isInjection (obj: Request | Response): boolean
+
+  interface InjectOptions {
+    url: string | {
+      pathname: string
+      protocal?: string
+      hostname?: string
+      port?: any
+      query?: any
+    }
+    headers?: http.IncomingHttpHeaders | http.OutgoingHttpHeaders
+    query?: any
+    simulate?: {
+      end: boolean,
+      split: boolean,
+      error: boolean,
+      close: boolean
+    }
+    authority?: string
+    remoteAddress?: string
+    method?: HTTPMethods
+    validate?: boolean
+    payload?: any
+    server?: http.Server
+  }
+
+  interface Request<Payload = string> extends stream.Readable {
+    url: string
+    httpVersion: string
+    method: HTTPMethods
+    headers: http.IncomingHttpHeaders
+    connection: string
+    _lightMyRequest: {
+      payload: Payload
+      isDone: boolean,
+      simulate: {
+        end: boolean,
+        split: boolean,
+        error: boolean,
+        close: boolean
+      }
+    }
+    prepare: (next: () => void) => void
+    _read: () => void
+  }
+
+  interface Response extends http.ServerResponse {
+    _lightMyRequest: {
+      headers: http.OutgoingHttpHeaders,
+      trailers: { [key: string]: string },
+      payloadChunks: Array<Buffer>
+    }
+    _headers: http.OutgoingHttpHeaders
+    _promiseCallback: boolean
+    addTrailers: (trailers: { [key: string]: string }) => void
+  }
+}
+
+export = LightMyRequest

--- a/package.json
+++ b/package.json
@@ -7,17 +7,21 @@
     "ajv": "^6.8.1",
     "readable-stream": "^3.1.1"
   },
+  "types": "index.d.ts",
   "devDependencies": {
+    "@types/node": "^11.11.4",
     "form-data": "^2.3.3",
     "pre-commit": "^1.2.2",
     "standard": "^12.0.0",
-    "tap": "^12.5.1"
+    "tap": "^12.5.1",
+    "tsd": "^0.7.0"
   },
   "scripts": {
     "test": "npm run lint && npm run unit",
     "lint": "standard",
     "unit": "tap test/test.js",
-    "coverage": "npm run unit -- --cov --coverage-report=html"
+    "coverage": "npm run unit -- --cov --coverage-report=html",
+    "test:tsd": "tsd"
   },
   "repository": {
     "type": "git",
@@ -35,5 +39,8 @@
   "bugs": {
     "url": "https://github.com/fastify/light-my-request/issues"
   },
-  "homepage": "https://github.com/fastify/light-my-request/blob/master/README.md"
+  "homepage": "https://github.com/fastify/light-my-request/blob/master/README.md",
+  "tsd": {
+    "directory": "test"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "tsd": "^0.7.0"
   },
   "scripts": {
-    "test": "npm run lint && npm run unit",
+    "test": "npm run lint && npm run unit && npm run tsd",
     "lint": "standard",
     "unit": "tap test/test.js",
     "coverage": "npm run unit -- --cov --coverage-report=html",
-    "test:tsd": "tsd"
+    "tsd": "tsd"
   },
   "repository": {
     "type": "git",

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,0 +1,25 @@
+import { inject, isInjection, Request, Response, DispatchFunc, InjectOptions } from '../index'
+import { expectType } from 'tsd'
+
+expectType<InjectOptions>({ url: '/' })
+
+const dispatch = function (req: Request, res: Response) {
+  expectType<boolean>(isInjection(req))
+  expectType<boolean>(isInjection(res))
+
+  const reply = 'Hello World'
+  res.writeHead(200, { 'Content-Type': 'text/plain', 'Content-Length': reply.length })
+  res.end(reply)
+}
+
+expectType<DispatchFunc>(dispatch)
+
+inject(dispatch, { method: 'get', url: '/' }, (err, res) => {
+  expectType<Error>(err)
+  expectType<Response>(res)
+  console.log(res.payload)
+})
+
+expectType<Promise<Response>>(inject(dispatch, { method: 'get', url: '/' }))
+// @ts-ignore tsd supports top-level await, but normal ts does not so ignore
+expectType<Response>(await inject(dispatch, { method: 'get', url: '/' }))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "noImplicitAny": true
   },
   "files": [
-    "./test.ts"
+    "./test.ts",
+    "./test/index.test-d.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "noImplicitAny": true
   },
   "files": [
-    "./test.ts",
     "./test/index.test-d.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "noEmit": true,
+    "strict": true,
+    "noImplicitAny": true
+  },
+  "files": [
+    "./test.ts"
+  ]
+}


### PR DESCRIPTION
Spent some time trying to complete this tonight. Please review as accurately as possible. All of my types are from reading the code. I based some off of the JSON Schema object but also included anything written in the documentation too. There were a couple `any` types I'd like to see if we can make more specific, as well as some general questions I have: 

- Is the `port` property on the `InjectOptions.url` type of `string | number`?
- What is `query`? Could this be typed as `string`?
- What types can `payload` be? I've implemented it as a generic for now but I think we can scope this to an union type list: `string | object | Buffer | NodeJS.ReadableStream` (this is actually copied from the current `fastify.d.ts` types `HTTPInjectOptions` so I believe it should be safe to implement here as well). Depending on what happens here I'll most likely be removing the generic.
- Am I correct that `Response._lightMyRequest.payloadChunks` is of type `Array<Buffer>`?

Not ready to be merged yet as I'm still playing with `tsd` to test the new types. It is a young module with a tiny API so it might not be quite ready yet, but I'd like to revisit it with a clear head tomorrow.

Finally, I need to experiment with the declaration file exports, namespace, and some of the internal TSC stuff I used (such as `interface`) to make sure it is correct.