### PR TITLE
 Use path as alias of url

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,16 @@ File uploads (multipart/form-data) can be achieved by using [form-data](https://
 ```js
 const FormData = require('form-data')
 const fs = require('fs')
- 
+
 try {
   const form = new FormData()
   form.append('myfile', fs.createReadStream(`./path/to/file`))
 
-  const res = await inject(dispatch, { 
-    method: 'post', 
-    url: '/upload', 
-    payload: form, 
-    headers: form.getHeaders() 
+  const res = await inject(dispatch, {
+    method: 'post',
+    url: '/upload',
+    payload: form,
+    headers: form.getHeaders()
   })
   console.log(res.payload)
 } catch (err) {
@@ -111,7 +111,7 @@ Injects a fake request into an HTTP server.
     - `req` - a simulated request object. Inherits from `Stream.Readable`.
     - `res` - a simulated response object. Inherits from node's `Http.ServerResponse`.
 - `options` - request options object where:
-  - `url` - a string specifying the request URL.
+  - `url` | `path` - a string specifying the request URL.
   - `method` - a string specifying the HTTP request method, defaulting to `'GET'`.
   - `authority` - a string specifying the HTTP HOST header value to be used if no header is provided, and the `url`
     does not include an authority component. Defaults to `'localhost'`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,14 @@ declare namespace LightMyRequest {
   function isInjection (obj: Request | Response): boolean
 
   interface InjectOptions {
-    url: string | {
+    url?: string | {
+      pathname: string
+      protocal?: string
+      hostname?: string
+      port?: string | number
+      query?: string
+    }
+    path?: string | {
       pathname: string
       protocal?: string
       hostname?: string

--- a/index.js
+++ b/index.js
@@ -6,27 +6,30 @@ const Ajv = require('ajv')
 const Request = require('./lib/request')
 const Response = require('./lib/response')
 
+const urlSchema = {
+  oneOf: [
+    { type: 'string' },
+    {
+      type: 'object',
+      properties: {
+        protocol: { type: 'string' },
+        hostname: { type: 'string' },
+        pathname: { type: 'string' }
+        // port type => any
+        // query type => any
+      },
+      additionalProperties: true,
+      required: ['pathname']
+    }
+  ]
+}
+
 const ajv = new Ajv()
 const schema = {
   type: 'object',
   properties: {
-    url: {
-      oneOf: [
-        { type: 'string' },
-        {
-          type: 'object',
-          properties: {
-            protocol: { type: 'string' },
-            hostname: { type: 'string' },
-            pathname: { type: 'string' }
-            // port type => any
-            // query type => any
-          },
-          additionalProperties: true,
-          required: ['pathname']
-        }
-      ]
-    },
+    url: urlSchema,
+    path: urlSchema,
     headers: {
       type: 'object',
       additionalProperties: true
@@ -51,7 +54,10 @@ const schema = {
     // payload type => any
   },
   additionalProperties: true,
-  required: ['url']
+  oneOf: [
+    { required: ['url'] },
+    { required: ['path'] }
+  ]
 }
 
 const optsValidator = ajv.compile(schema)

--- a/lib/request.js
+++ b/lib/request.js
@@ -22,7 +22,7 @@ function hostHeaderFromURL (parsedURL) {
  *
  * @constructor
  * @param {Object} options
- * @param {(Object|String)} options.url
+ * @param {(Object|String)} options.url || options.path
  * @param {String} [options.method='GET']
  * @param {String} [options.remoteAddress]
  * @param {Object} [options.headers]
@@ -32,7 +32,7 @@ function hostHeaderFromURL (parsedURL) {
 function Request (options) {
   Readable.call(this)
 
-  const parsedURL = parseURL(options.url, options.query)
+  const parsedURL = parseURL(options.url || options.path, options.query)
 
   this.url = parsedURL.pathname + parsedURL.search
 

--- a/test/test.js
+++ b/test/test.js
@@ -884,6 +884,31 @@ test('form-data should be handled correctly', (t) => {
   })
 })
 
+test('path as alias to url', (t) => {
+  t.plan(2)
+
+  const dispatch = function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end(req.url)
+  }
+
+  inject(dispatch, { method: 'GET', path: 'http://example.com:8080/hello' }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.payload, '/hello')
+  })
+})
+
+test('Should throw if both path and url are missing', (t) => {
+  t.plan(1)
+
+  try {
+    inject(() => {}, { method: 'GET' }, () => {})
+    t.fail('Should throw')
+  } catch (err) {
+    t.ok(err)
+  }
+})
+
 function getTestStream (encoding) {
   const word = 'hi'
   let i = 0


### PR DESCRIPTION
Since in the Fastify route declaration we support both `url` and `path`, we should do the same here.