### PR TITLE
Fix dep0066

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -13,7 +13,8 @@ function Response (req, onEnd, reject) {
 
   this._lightMyRequest = { headers: null, trailers: {}, payloadChunks: [] }
   // This forces node@8 to always render the headers
-  this._headers = {}
+  this.setHeader('foo', 'bar'); this.removeHeader('foo')
+
   this.assignSocket(getNullSocket())
 
   this._promiseCallback = typeof reject === 'function'
@@ -48,8 +49,8 @@ util.inherits(Response, http.ServerResponse)
 Response.prototype.writeHead = function () {
   const result = http.ServerResponse.prototype.writeHead.apply(this, arguments)
 
-  // Should be .getHeaders() since node v7.7
-  this._lightMyRequest.headers = Object.assign({}, this._headers)
+  const _headers = this.getHeaders()
+  this._lightMyRequest.headers = Object.assign({}, _headers)
 
   // Add raw headers
   ;['Date', 'Connection', 'Transfer-Encoding'].forEach((name) => {

--- a/lib/response.js
+++ b/lib/response.js
@@ -49,7 +49,7 @@ util.inherits(Response, http.ServerResponse)
 Response.prototype.writeHead = function () {
   const result = http.ServerResponse.prototype.writeHead.apply(this, arguments)
 
-  const _headers = this.getHeaders()
+  const _headers = this.getHeaders ? this.getHeaders() : this._headers
   this._lightMyRequest.headers = Object.assign({}, _headers)
 
   // Add raw headers


### PR DESCRIPTION
Fixes _headers deprecation warning in Node v12. See issue #44 