### PR TITLE
Add json() handler for Response

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,7 @@ declare namespace LightMyRequest {
     payload: string
     body: string
     addTrailers: (trailers: { [key: string]: string }) => void
+    json: (json: object) => void
   }
 }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -79,6 +79,11 @@ Response.prototype.end = function (data, encoding, callback) {
   this.emit('finish')
 }
 
+Response.prototype.json = function (data, encoding, callback) {
+  this.setHeader('content-type', 'application/json')
+  this.end(JSON.stringify(data), encoding, callback)
+}
+
 Response.prototype.destroy = function () {}
 
 Response.prototype.addTrailers = function (trailers) {

--- a/test/test.js
+++ b/test/test.js
@@ -909,6 +909,25 @@ test('Should throw if both path and url are missing', (t) => {
   }
 })
 
+test('Response.json() should send a JSON response', (t) => {
+  t.plan(3)
+
+  const json = {
+    a: 1,
+    b: '2'
+  }
+
+  const dispatch = function (req, res) {
+    res.json(json)
+  }
+
+  inject(dispatch, { method: 'GET', path: 'http://example.com:8080/hello' }, (err, res) => {
+    t.error(err)
+    t.equal(res.headers['content-type'], 'application/json')
+    t.strictEqual(res.payload, JSON.stringify(json))
+  })
+})
+
 function getTestStream (encoding) {
   const word = 'hi'
   let i = 0


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

Add `json()` handler for Response.
And I'm wondering if error thrown by `JSON.stringify` shoud be handled.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
