### PR TITLE
Override Response.setTimeout to make response timeout handler work

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -48,11 +48,9 @@ util.inherits(Response, http.ServerResponse)
 
 Response.prototype.setTimeout = function (msecs, callback) {
   this.timeoutHandle = setTimeout(() => {
-    this.socket.emit('timeout')
-    if (callback) {
-      callback()
-    }
+    this.emit('timeout')
   }, msecs)
+  this.on('timeout', callback)
   return this
 }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -46,18 +46,17 @@ function Response (req, onEnd, reject) {
 
 util.inherits(Response, http.ServerResponse)
 
-let timeoutHandle
 Response.prototype.setTimeout = function (msecs, callback) {
-  if (callback) {
-    timeoutHandle = setTimeout(callback, msecs)
-  }
+  this.timeoutHandle = setTimeout(() => {
+    this.socket.emit('timeout')
+    if (callback) {
+      callback()
+    }
+  }, msecs)
   return this
 }
 
 Response.prototype.writeHead = function () {
-  if (timeoutHandle) {
-    clearTimeout(timeoutHandle)
-  }
   const result = http.ServerResponse.prototype.writeHead.apply(this, arguments)
 
   const _headers = this.getHeaders ? this.getHeaders() : this._headers
@@ -76,6 +75,9 @@ Response.prototype.writeHead = function () {
 }
 
 Response.prototype.write = function (data, encoding, callback) {
+  if (this.timeoutHandle) {
+    clearTimeout(this.timeoutHandle)
+  }
   http.ServerResponse.prototype.write.call(this, data, encoding, callback)
   this._lightMyRequest.payloadChunks.push(Buffer.from(data, encoding))
   return true

--- a/lib/response.js
+++ b/lib/response.js
@@ -46,7 +46,18 @@ function Response (req, onEnd, reject) {
 
 util.inherits(Response, http.ServerResponse)
 
+let timeoutHandle
+Response.prototype.setTimeout = function (msecs, callback) {
+  if (callback) {
+    timeoutHandle = setTimeout(callback, msecs)
+  }
+  return this
+}
+
 Response.prototype.writeHead = function () {
+  if (timeoutHandle) {
+    clearTimeout(timeoutHandle)
+  }
   const result = http.ServerResponse.prototype.writeHead.apply(this, arguments)
 
   const _headers = this.getHeaders ? this.getHeaders() : this._headers

--- a/test/test.js
+++ b/test/test.js
@@ -859,8 +859,8 @@ test('should handle response timeout handler', (t) => {
       res.writeHead(200, { 'Content-Type': 'text/plain' })
       res.end('correct')
     })
-    res.socket.on('timeout', () => {
-      t.ok(true, 'Socket timeout event not emitted')
+    res.on('timeout', () => {
+      t.ok(true, 'Response timeout event not emitted')
     })
   }
   inject(dispatch, { method: 'GET', url: '/test' }, (err, res) => {

--- a/test/test.js
+++ b/test/test.js
@@ -848,7 +848,7 @@ test('should handle response errors (promises)', (t) => {
 })
 
 test('should handle response timeout handler', (t) => {
-  t.plan(2)
+  t.plan(3)
   const dispatch = function (req, res) {
     const handle = setTimeout(() => {
       res.writeHead(200, { 'Content-Type': 'text/plain' })
@@ -859,8 +859,10 @@ test('should handle response timeout handler', (t) => {
       res.writeHead(200, { 'Content-Type': 'text/plain' })
       res.end('correct')
     })
+    res.socket.on('timeout', () => {
+      t.ok(true, 'Socket timeout event not emitted')
+    })
   }
-
   inject(dispatch, { method: 'GET', url: '/test' }, (err, res) => {
     t.error(err)
     t.equal(res.payload, 'correct')

--- a/test/test.js
+++ b/test/test.js
@@ -847,6 +847,26 @@ test('should handle response errors (promises)', (t) => {
     .catch(err => t.ok(err))
 })
 
+test('should handle response timeout handler', (t) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    const handle = setTimeout(() => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
+      res.end('incorrect')
+    }, 200)
+    res.setTimeout(100, () => {
+      clearTimeout(handle)
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
+      res.end('correct')
+    })
+  }
+
+  inject(dispatch, { method: 'GET', url: '/test' }, (err, res) => {
+    t.error(err)
+    t.equal(res.payload, 'correct')
+  })
+})
+
 test('should throw on unknown HTTP method', (t) => {
   t.plan(1)
   const dispatch = function (req, res) { }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
