### PR TITLE
Validate headers value

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,9 +37,7 @@ const schema = {
     },
     headers: {
       type: 'object',
-      additionalProperties: {
-        type: 'string'
-      }
+      additionalProperties: true
     },
     query: {
       type: 'object',

--- a/index.js
+++ b/index.js
@@ -37,7 +37,9 @@ const schema = {
     },
     headers: {
       type: 'object',
-      additionalProperties: true
+      additionalProperties: {
+        type: 'string'
+      }
     },
     query: {
       type: 'object',

--- a/lib/request.js
+++ b/lib/request.js
@@ -46,7 +46,11 @@ function Request (options) {
   this.headers = {}
   const headers = options.headers || {}
   Object.keys(headers).forEach((field) => {
-    this.headers[field.toLowerCase()] = headers[field]
+    const value = headers[field]
+    if (value === undefined) {
+      throw new Error('Invalid header value: invalid value "undefined" for header ' + field)
+    }
+    this.headers[field.toLowerCase()] = '' + headers[field]
   })
 
   this.headers['user-agent'] = this.headers['user-agent'] || 'lightMyRequest'

--- a/lib/request.js
+++ b/lib/request.js
@@ -5,6 +5,7 @@
 const { Readable } = require('readable-stream')
 const util = require('util')
 const cookie = require('cookie')
+const assert = require('assert')
 
 const parseURL = require('./parseURL')
 
@@ -47,10 +48,8 @@ function Request (options) {
   const headers = options.headers || {}
   Object.keys(headers).forEach((field) => {
     const value = headers[field]
-    if (value === undefined) {
-      throw new Error('Invalid header value: invalid value "undefined" for header ' + field)
-    }
-    this.headers[field.toLowerCase()] = '' + headers[field]
+    assert(value !== undefined, 'invalid value "undefined" for header ' + field)
+    this.headers[field.toLowerCase()] = '' + value
   })
 
   this.headers['user-agent'] = this.headers['user-agent'] || 'lightMyRequest'

--- a/test/test.js
+++ b/test/test.js
@@ -1446,7 +1446,9 @@ test('correctly handles no string headers', (t) => {
     string: 'string',
     object: { foo: 'bar' },
     array: [1, 'two', 3],
-    date
+    date,
+    true: true,
+    false: false
   }
 
   inject(dispatch, { method: 'GET', url: 'http://example.com:8080/hello', headers }, (err, res) => {
@@ -1459,6 +1461,8 @@ test('correctly handles no string headers', (t) => {
       object: '[object Object]',
       array: '1,two,3',
       date: date.toString(),
+      true: 'true',
+      false: 'false',
       host: 'example.com:8080',
       'user-agent': 'lightMyRequest'
     })

--- a/test/test.js
+++ b/test/test.js
@@ -761,6 +761,15 @@ test('errors for missing url', (t) => {
   }
 })
 
+test('errors for invalid headers', (t) => {
+  t.plan(1)
+  try {
+    inject((req, res) => {}, { url: '/', headers: { 'not-a-string': 12 } }, () => {})
+  } catch (err) {
+    t.ok(err)
+  }
+})
+
 test('errors for an incorrect simulation object', (t) => {
   t.plan(1)
   try {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

Headers value must be a string, but adding key to a javascript object sometimes by mistake you could add a number, an array, an object or something different from a string.
In this case, the test may incorrectly pass.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
