### PR TITLE
fix incorrect typescript defs for query

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ declare namespace LightMyRequest {
       protocal?: string
       hostname?: string
       port?: string | number
-      query?: string
+      query?: string | any
     }
     path?: string | {
       pathname: string
@@ -44,7 +44,7 @@ declare namespace LightMyRequest {
       query?: string
     }
     headers?: http.IncomingHttpHeaders | http.OutgoingHttpHeaders
-    query?: string
+    query?: string | any
     simulate?: {
       end: boolean,
       split: boolean,

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,17 +34,17 @@ declare namespace LightMyRequest {
       protocal?: string
       hostname?: string
       port?: string | number
-      query?: string | any
+      query?: string | { [k: string]: string }
     }
     path?: string | {
       pathname: string
       protocal?: string
       hostname?: string
       port?: string | number
-      query?: string
+      query?: string | { [k: string]: string }
     }
     headers?: http.IncomingHttpHeaders | http.OutgoingHttpHeaders
-    query?: string | any
+    query?: string | { [k: string]: string }
     simulate?: {
       end: boolean,
       split: boolean,

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -30,6 +30,14 @@ inject(dispatch, { method: 'get', url: '/', cookies: { name1: 'value1', value2: 
   console.log(res.cookies)
 })
 
+inject(dispatch, { method: 'get', url: '/', query: { name1: 'value1', value2: 'value2' } }, (err, res) => {
+  expectType<Error>(err)
+  expectType<Response>(res)
+  console.log(res.payload)
+  expectType<Function>(res.json)
+  console.log(res.cookies)
+})
+
 inject(dispatch)
   .get('/')
   .end((err, res) => {


### PR DESCRIPTION
this PR fixes wrong typescript definitions for the `query` object in `HttpInjectOptions`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
