### PR TITLE
Add missing query param multi-value type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,17 +34,17 @@ declare namespace LightMyRequest {
       protocal?: string
       hostname?: string
       port?: string | number
-      query?: string | { [k: string]: string }
+      query?: string | { [k: string]: string | string[] }
     }
     path?: string | {
       pathname: string
       protocal?: string
       hostname?: string
       port?: string | number
-      query?: string | { [k: string]: string }
+      query?: string | { [k: string]: string | string[] }
     }
     headers?: http.IncomingHttpHeaders | http.OutgoingHttpHeaders
-    query?: string | { [k: string]: string }
+    query?: string | { [k: string]: string | string[] }
     simulate?: {
       end: boolean,
       split: boolean,

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -38,6 +38,14 @@ inject(dispatch, { method: 'get', url: '/', query: { name1: 'value1', value2: 'v
   console.log(res.cookies)
 })
 
+inject(dispatch, { method: 'get', url: '/', query: { name1: ['value1', 'value2'] } }, (err, res) => {
+  expectType<Error>(err)
+  expectType<Response>(res)
+  console.log(res.payload)
+  expectType<Function>(res.json)
+  console.log(res.cookies)
+})
+
 inject(dispatch)
   .get('/')
   .end((err, res) => {


### PR DESCRIPTION
The implementation allows to provide multiple query param values for the same key like: `query: { fields: ["a", "b"] }`. This PR adds the corresponding type definitions to stay in sync with the implementation.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
