### PR TITLE
fix: Match Response.json() type to JSON.parse()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,7 @@ declare namespace LightMyRequest {
     trailers: { [key: string]: string }
     payload: string
     body: string
-    json: () => object
+    json: () => any
     cookies: Array<object>
   }
 


### PR DESCRIPTION
This patch updates the `Response.json()` type to mirror the result of Node's `JSON.parse()` interface. Previously, `json()` was defined as returning `object`; while this may appear correct from a "human" point-of-view, this is actually the same as saying that the `json()` always returns an empty Object, which is incorrect.

Fixes: #82 