### PR TITLE
Add overload for `inject` to support builder-style usage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ declare namespace LightMyRequest {
     dispatchFunc: DispatchFunc,
     options?: string | InjectOptions
   ): Chain
+  function inject (): Chain
   function inject (
     dispatchFunc: DispatchFunc,
     options: string | InjectOptions,

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -73,7 +73,7 @@ inject(dispatch)
 
 expectType<Chain>(inject(dispatch))
 expectType<Promise<Response>>(inject(dispatch).end())
-expectType<Chain | Promise<Response>>(
+expectType<Promise<Response>>(
     inject()
         .get('/')
         .headers({ foo: 'bar' })
@@ -91,4 +91,3 @@ type ParsedValue = { field: string }
 const response: Response = await inject(dispatch)
 const parsedValue: ParsedValue = response.json()
 expectType<ParsedValue>(parsedValue)
-

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -71,7 +71,9 @@ inject(dispatch)
     console.log(res.payload)
   })
 
+expectType<Chain>(inject())
 expectType<Chain>(inject(dispatch))
 expectType<Chain>(inject(dispatch, { method: 'get', url: '/' }))
 // @ts-ignore tsd supports top-level await, but normal ts does not so ignore
 expectType<Response>(await inject(dispatch, { method: 'get', url: '/' }))
+

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -71,8 +71,15 @@ inject(dispatch)
     console.log(res.payload)
   })
 
-expectType<Chain>(inject())
-expectType<Chain>(inject(dispatch))
+expectType<Chain | Promise<Response>>(
+    inject()
+        .get('/')
+        .headers({ foo: 'bar' })
+        .query({ foo: 'bar' })
+        .end((err, res) => {
+        })
+)
+
 expectType<Chain>(inject(dispatch, { method: 'get', url: '/' }))
 // @ts-ignore tsd supports top-level await, but normal ts does not so ignore
 expectType<Response>(await inject(dispatch, { method: 'get', url: '/' }))


### PR DESCRIPTION
fixes https://github.com/fastify/fastify/issues/2142

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
