### PR TITLE
Fix type returned by `end()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -97,7 +97,7 @@ declare namespace LightMyRequest {
     payload: (payload: InjectPayload) => Chain
     query: (query: object) => Chain
     cookies: (query: object) => Chain
-    end: (callback?: CallbackFunc) => Chain | Promise<Response>
+    end: (callback?: CallbackFunc) => Promise<Response>
   }
 }
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -72,6 +72,7 @@ inject(dispatch)
   })
 
 expectType<Chain>(inject(dispatch))
+expectType<Promise<Response>>(inject(dispatch).end())
 expectType<Chain>(inject(dispatch, { method: 'get', url: '/' }))
 // @ts-ignore tsd supports top-level await, but normal ts does not so ignore
 expectType<Response>(await inject(dispatch, { method: 'get', url: '/' }))


### PR DESCRIPTION
Currently `end()` is useless because even when it's used TypeScript complains about value potentially being `Chain` and does not compile properly without explicit casts or ignores.

However, it doesn't look like `Chain` is actually ever returned from that code:
```
Chain.prototype.end = function (callback) {
  if (this._hasInvoked === true || this._promise) {
    throw new Error(errorMessage)
  }
  this._hasInvoked = true
  if (typeof callback === 'function') {
    doInject(this.dispatch, this.option, callback)
  } else {
    this._promise = doInject(this.dispatch, this.option)
    return this._promise
  }
}
```

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
