### PR TITLE
Fix type for Response.json()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,7 @@ declare namespace LightMyRequest {
     trailers: { [key: string]: string }
     payload: string
     body: string
-    json: () => object
+    json: () => any
     cookies: Array<object>
   }
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -75,3 +75,9 @@ expectType<Chain>(inject(dispatch))
 expectType<Chain>(inject(dispatch, { method: 'get', url: '/' }))
 // @ts-ignore tsd supports top-level await, but normal ts does not so ignore
 expectType<Response>(await inject(dispatch, { method: 'get', url: '/' }))
+
+type ParsedValue = { field: string }
+// @ts-ignore tsd supports top-level await, but normal ts does not so ignore
+const response: Response = await inject(dispatch)
+const parsedValue: ParsedValue = response.json()
+expectType<ParsedValue>(parsedValue)


### PR DESCRIPTION
fixes #82
inspired by #83

type `any` was chosen as per instructions from @mcollina to replicate what JSON.parse is returning.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
