### PR TITLE
Add missing type for Response.raw.req

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,8 @@ declare namespace LightMyRequest {
 
   interface Response extends http.ServerResponse {
     raw: {
-      res: http.ServerResponse
+      res: http.ServerResponse,
+      req: Request
     }
     rawPayload: Buffer
     headers: http.OutgoingHttpHeaders

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,3 +1,4 @@
+import * as http from 'http'
 import { inject, isInjection, Request, Response, DispatchFunc, InjectOptions, Chain } from '../index'
 import { expectType, expectAssignable } from 'tsd'
 
@@ -12,14 +13,20 @@ const dispatch = function (req: Request, res: Response) {
   res.end(reply)
 }
 
+const expectResponse = function (res: Response) {
+  expectType<Response>(res)
+  console.log(res.payload)
+  expectAssignable<Function>(res.json)
+  expectAssignable<http.ServerResponse>(res.raw.res)
+  expectAssignable<Request>(res.raw.req)
+  console.log(res.cookies)
+}
+
 expectType<DispatchFunc>(dispatch)
 
 inject(dispatch, { method: 'get', url: '/' }, (err, res) => {
   expectType<Error>(err)
-  expectType<Response>(res)
-  console.log(res.payload)
-  expectAssignable<Function>(res.json)
-  console.log(res.cookies)
+  expectResponse(res)
 })
 
 const url = {
@@ -33,34 +40,22 @@ const url = {
 }
 inject(dispatch, { method: 'get', url }, (err, res) => {
   expectType<Error>(err)
-  expectType<Response>(res)
-  console.log(res.payload)
-  expectAssignable<Function>(res.json)
-  console.log(res.cookies)
+  expectResponse(res)
 })
 
 inject(dispatch, { method: 'get', url: '/', cookies: { name1: 'value1', value2: 'value2' } }, (err, res) => {
   expectType<Error>(err)
-  expectType<Response>(res)
-  console.log(res.payload)
-  expectAssignable<Function>(res.json)
-  console.log(res.cookies)
+  expectResponse(res)
 })
 
 inject(dispatch, { method: 'get', url: '/', query: { name1: 'value1', value2: 'value2' } }, (err, res) => {
   expectType<Error>(err)
-  expectType<Response>(res)
-  console.log(res.payload)
-  expectAssignable<Function>(res.json)
-  console.log(res.cookies)
+  expectResponse(res)
 })
 
 inject(dispatch, { method: 'get', url: '/', query: { name1: ['value1', 'value2'] } }, (err, res) => {
   expectType<Error>(err)
-  expectType<Response>(res)
-  console.log(res.payload)
-  expectAssignable<Function>(res.json)
-  console.log(res.cookies)
+  expectResponse(res)
 })
 
 inject(dispatch)


### PR DESCRIPTION
It's added here: https://github.com/fastify/light-my-request/blob/master/lib/response.js#L40

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
  - Note: couldn't find anything about commit message requirements
