### PR TITLE
fix: change this to res in response.js

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -126,7 +126,7 @@ function generatePayload (response) {
 
   // Prepare payload parsers
   res.json = function parseJsonPayload () {
-    if (this.headers['content-type'].indexOf('application/json') < 0) {
+    if (res.headers['content-type'].indexOf('application/json') < 0) {
       throw new Error('The content-type of the response is not application/json')
     }
     return JSON.parse(this.payload)


### PR DESCRIPTION
I wanted to cover Line 130 in `repsonse.js`:

```
response.js         |    98.65 |    85.71 |    95.24 |    98.55 |               130 |
```

Already had a test case to cover this: 

```
test('Response.json() should throw an error if content-type is not application/json'
```

Which was passing, but throwing a different error to what we expect and therefore never entering Line 130. 

```
      type: TypeError
      message: Cannot read property 'headers' of undefined
      source: >2
          res.json = function parseJsonPayload () {
            if (this.headers['content-type'].indexOf('application/json') < 0) {
        -------------^
              throw new Error('The content-type of the response is not application/json')
            }
```

Tests pass and coverage is increased. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
