### PR TITLE
[feat types] using generic type for request json parser

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,7 @@ declare namespace LightMyRequest {
     trailers: { [key: string]: string }
     payload: string
     body: string
-    json: () => any
+    json: <T = any>() => T
     cookies: Array<object>
   }
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -77,3 +77,6 @@ type ParsedValue = { field: string }
 const response: Response = await inject(dispatch)
 const parsedValue: ParsedValue = response.json()
 expectType<ParsedValue>(parsedValue)
+
+const parsedValueUsingGeneric = response.json<ParsedValue>()
+expectType<ParsedValue>(parsedValueUsingGeneric)


### PR DESCRIPTION
It's better to use an optional generic for response json parser method:

Sample usage:
```ts
interface Response {
   code: string
}

async function getCode(): string {
   const result = await inject(dispatch)
   return result.json<Response>().code
}
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] ~~documentation is changed or added~~ (it's not necessary)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
