### PR TITLE
fix: add missing request.socket (#87)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,6 +66,8 @@ declare namespace LightMyRequest {
     method: HTTPMethods
     headers: http.IncomingHttpHeaders
     prepare: (next: () => void) => void
+    // @deprecated
+    connection: object
   }
 
   interface Response extends http.ServerResponse {

--- a/lib/request.js
+++ b/lib/request.js
@@ -67,6 +67,7 @@ function Request (options) {
   this.connection = {
     remoteAddress: options.remoteAddress || '127.0.0.1'
   }
+  this.socket = this.connection
 
   // we keep both payload and body for compatibility reasons
   var payload = options.payload || options.body || null

--- a/lib/request.js
+++ b/lib/request.js
@@ -6,8 +6,13 @@ const { Readable } = require('readable-stream')
 const util = require('util')
 const cookie = require('cookie')
 const assert = require('assert')
+const semver = require('semver')
+const warning = require('fastify-warning')()
 
 const parseURL = require('./parseURL')
+
+// request.connectin deprecation https://nodejs.org/api/http.html#http_request_connection
+warning.create('FastifyDeprecationLightMyRequest', 'FST_LIGHTMYREQUEST_DEP01', 'You are accessing "request.connection", use "request.socket" instead.')
 
 /**
  * Get hostname:port
@@ -70,7 +75,9 @@ function Request (options) {
 
   Object.defineProperty(this, 'connection', {
     get () {
-      // if node major ≥13 emit a warning with https://github.com/fastify/fastify-warning
+      if (semver.gte(process.versions.node, '13.0.0')) {
+        warning.emit('FST_LIGHTMYREQUEST_DEP01')
+      }
       return this.socket
     },
     configurable: true

--- a/lib/request.js
+++ b/lib/request.js
@@ -6,7 +6,6 @@ const { Readable } = require('readable-stream')
 const util = require('util')
 const cookie = require('cookie')
 const assert = require('assert')
-const semver = require('semver')
 const warning = require('fastify-warning')()
 
 const parseURL = require('./parseURL')
@@ -75,9 +74,7 @@ function Request (options) {
 
   Object.defineProperty(this, 'connection', {
     get () {
-      if (semver.gte(process.versions.node, '13.0.0')) {
-        warning.emit('FST_LIGHTMYREQUEST_DEP01')
-      }
+      warning.emit('FST_LIGHTMYREQUEST_DEP01')
       return this.socket
     },
     configurable: true

--- a/lib/request.js
+++ b/lib/request.js
@@ -64,10 +64,17 @@ function Request (options) {
     this.headers.cookie = cookieValues.join('; ')
   }
 
-  this.connection = {
+  this.socket = {
     remoteAddress: options.remoteAddress || '127.0.0.1'
   }
-  this.socket = this.connection
+
+  Object.defineProperty(this, 'connection', {
+    get () {
+      // if node major ≥13 emit a warning with https://github.com/fastify/fastify-warning
+      return this.socket
+    },
+    configurable: true
+  })
 
   // we keep both payload and body for compatibility reasons
   var payload = options.payload || options.body || null

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "dependencies": {
     "ajv": "^6.12.2",
     "cookie": "^0.4.0",
+    "fastify-warning": "^0.2.0",
     "readable-stream": "^3.6.0",
+    "semver": "^7.3.2",
     "set-cookie-parser": "^2.4.1"
   },
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "cookie": "^0.4.0",
     "fastify-warning": "^0.2.0",
     "readable-stream": "^3.6.0",
-    "semver": "^7.3.2",
     "set-cookie-parser": "^2.4.1"
   },
   "types": "index.d.ts",

--- a/test/test.js
+++ b/test/test.js
@@ -87,6 +87,19 @@ test('passes remote address', (t) => {
   t.plan(2)
   const dispatch = function (req, res) {
     res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end(req.socket.remoteAddress)
+  }
+
+  inject(dispatch, { method: 'GET', url: 'http://example.com:8080/hello', remoteAddress: '1.2.3.4' }, (err, res) => {
+    t.error(err)
+    t.equal(res.payload, '1.2.3.4')
+  })
+})
+
+test('includes deprecated connection on request', (t) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
     res.end(req.connection.remoteAddress)
   }
 
@@ -142,7 +155,7 @@ test('passes localhost as default remote address', (t) => {
   t.plan(2)
   const dispatch = function (req, res) {
     res.writeHead(200, { 'Content-Type': 'text/plain' })
-    res.end(req.connection.remoteAddress)
+    res.end(req.socket.remoteAddress)
   }
 
   inject(dispatch, { method: 'GET', url: 'http://example.com:8080/hello' }, (err, res) => {


### PR DESCRIPTION
Fixes #87.  This adds the `.socket` property to `request`, mirroring the `.connection` property

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
