### PR TITLE
test: :white_check_mark: improve test line coverage

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -59,8 +59,7 @@ Response.prototype.setTimeout = function (msecs, callback) {
 Response.prototype.writeHead = function () {
   const result = http.ServerResponse.prototype.writeHead.apply(this, arguments)
 
-  const _headers = this.getHeaders ? this.getHeaders() : this._headers
-  this._lightMyRequest.headers = Object.assign({}, _headers)
+  this._lightMyRequest.headers = Object.assign({}, this.getHeaders())
 
   // Add raw headers
   ;['Date', 'Connection', 'Transfer-Encoding'].forEach((name) => {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "test": "npm run lint && npm run unit && npm run tsd",
     "lint": "standard",
-    "unit": "tap test/test.js",
+    "unit": "tap test/test.js --100",
     "coverage": "npm run unit -- --cov --coverage-report=html",
     "tsd": "tsd"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1552,3 +1552,15 @@ test('simulate invalid alter _lightMyRequest.isDone without end', (t) => {
     t.equal(replied, false)
   }, 10)
 })
+
+test('no error for response destory', (t) => {
+  const dispatch = function (req, res) {
+    res.destroy()
+  }
+
+  inject(dispatch, { method: 'GET', url: '/' }, (err, res) => {
+    t.error(err)
+  })
+
+  t.end()
+})

--- a/test/test.js
+++ b/test/test.js
@@ -1508,3 +1508,47 @@ test('example with form-auto-content', (t) => {
     t.ok(/--.+\r\nContent-Disposition: form-data; name="myFile"; filename="LICENSE"\r\n.*/.test(res.payload))
   })
 })
+
+test('simulate invalid alter _lightMyRequest.isDone with end', (t) => {
+  t.plan(2)
+  let end = false
+  const dispatch = function (req, res) {
+    req.resume()
+    req._lightMyRequest.isDone = true
+    req.on('end', () => {
+      end = true
+    })
+  }
+
+  let replied = false
+  inject(dispatch, { method: 'GET', url: '/', simulate: { end: true } }, (notHandledErr, res) => {
+    replied = true
+  })
+
+  setTimeout(() => {
+    t.equal(end, true)
+    t.equal(replied, false)
+  }, 10)
+})
+
+test('simulate invalid alter _lightMyRequest.isDone without end', (t) => {
+  t.plan(2)
+  let end = false
+  const dispatch = function (req, res) {
+    req.resume()
+    req._lightMyRequest.isDone = true
+    req.on('end', () => {
+      end = true
+    })
+  }
+
+  let replied = false
+  inject(dispatch, { method: 'GET', url: '/', simulate: { end: false } }, (notHandledErr, res) => {
+    replied = true
+  })
+
+  setTimeout(() => {
+    t.equal(end, false)
+    t.equal(replied, false)
+  }, 10)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -1525,12 +1525,10 @@ test('simulate invalid alter _lightMyRequest.isDone with end', (t) => {
     replied = true
   })
 
-  process.nextTick(() => {
-    setImmediate(() => {
-      t.equal(end, true)
-      t.equal(replied, false)
-    })
-  })
+  setTimeout(() => {
+    t.equal(end, true)
+    t.equal(replied, false)
+  }, 10)
 })
 
 test('simulate invalid alter _lightMyRequest.isDone without end', (t) => {
@@ -1549,12 +1547,10 @@ test('simulate invalid alter _lightMyRequest.isDone without end', (t) => {
     replied = true
   })
 
-  process.nextTick(() => {
-    setImmediate(() => {
-      t.equal(end, false)
-      t.equal(replied, false)
-    })
-  })
+  setTimeout(() => {
+    t.equal(end, false)
+    t.equal(replied, false)
+  }, 10)
 })
 
 test('no error for response destory', (t) => {

--- a/test/test.js
+++ b/test/test.js
@@ -1525,10 +1525,12 @@ test('simulate invalid alter _lightMyRequest.isDone with end', (t) => {
     replied = true
   })
 
-  setTimeout(() => {
-    t.equal(end, true)
-    t.equal(replied, false)
-  }, 10)
+  process.nextTick(() => {
+    setImmediate(() => {
+      t.equal(end, true)
+      t.equal(replied, false)
+    })
+  })
 })
 
 test('simulate invalid alter _lightMyRequest.isDone without end', (t) => {
@@ -1547,10 +1549,12 @@ test('simulate invalid alter _lightMyRequest.isDone without end', (t) => {
     replied = true
   })
 
-  setTimeout(() => {
-    t.equal(end, false)
-    t.equal(replied, false)
-  }, 10)
+  process.nextTick(() => {
+    setImmediate(() => {
+      t.equal(end, false)
+      t.equal(replied, false)
+    })
+  })
 })
 
 test('no error for response destory', (t) => {

--- a/test/test.js
+++ b/test/test.js
@@ -1510,47 +1510,34 @@ test('example with form-auto-content', (t) => {
 })
 
 test('simulate invalid alter _lightMyRequest.isDone with end', (t) => {
-  t.plan(2)
-  let end = false
   const dispatch = function (req, res) {
     req.resume()
     req._lightMyRequest.isDone = true
     req.on('end', () => {
-      end = true
+      t.pass('should have end event')
+      t.end()
     })
   }
 
-  let replied = false
   inject(dispatch, { method: 'GET', url: '/', simulate: { end: true } }, (notHandledErr, res) => {
-    replied = true
+    t.fail('should not have reply')
   })
-
-  setTimeout(() => {
-    t.equal(end, true)
-    t.equal(replied, false)
-  }, 10)
 })
 
 test('simulate invalid alter _lightMyRequest.isDone without end', (t) => {
-  t.plan(2)
-  let end = false
   const dispatch = function (req, res) {
     req.resume()
     req._lightMyRequest.isDone = true
     req.on('end', () => {
-      end = true
+      t.fail('should not have end event')
     })
   }
 
-  let replied = false
   inject(dispatch, { method: 'GET', url: '/', simulate: { end: false } }, (notHandledErr, res) => {
-    replied = true
+    t.fail('should not have reply')
   })
 
-  setTimeout(() => {
-    t.equal(end, false)
-    t.equal(replied, false)
-  }, 10)
+  t.end()
 })
 
 test('no error for response destory', (t) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Resolve #90 

For ```request.js``` L121
I do not see a reason the request will be end early without custom alter the ```_lightMyRequest``` object.
So, I decided to alter it in ```dispatch``` in order to reach the the line and pretend it is a invalid alter by user.

For ```response.ts``` L62
If this plugin do not support node 7.7.0 or early, this is never happen for the false condition.
[NodeJS Docs](https://nodejs.org/api/http.html#http_response_getheaders) for ```getHeaders```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
