### PR TITLE
Expose a mock socket that is an EventEmitter like a real one would be

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -9,6 +9,7 @@ const assert = require('assert')
 const warning = require('fastify-warning')()
 
 const parseURL = require('./parseURL')
+const { EventEmitter } = require('events')
 
 // request.connectin deprecation https://nodejs.org/api/http.html#http_request_connection
 warning.create('FastifyDeprecationLightMyRequest', 'FST_LIGHTMYREQUEST_DEP01', 'You are accessing "request.connection", use "request.socket" instead.')
@@ -23,6 +24,19 @@ function hostHeaderFromURL (parsedURL) {
   return parsedURL.port
     ? parsedURL.host
     : parsedURL.hostname + (parsedURL.protocol === 'https:' ? ':443' : ':80')
+}
+
+/**
+ * Mock socket object used to fake access to a socket for a request
+ *
+ * @constructor
+ * @param {String} remoteAddress the fake address to show consumers of the socket
+ */
+class MockSocket extends EventEmitter {
+  constructor (remoteAddress) {
+    super()
+    this.remoteAddress = remoteAddress
+  }
 }
 
 /**
@@ -68,9 +82,7 @@ function Request (options) {
     this.headers.cookie = cookieValues.join('; ')
   }
 
-  this.socket = {
-    remoteAddress: options.remoteAddress || '127.0.0.1'
-  }
+  this.socket = new MockSocket(options.remoteAddress || '127.0.0.1')
 
   Object.defineProperty(this, 'connection', {
     get () {

--- a/test/test.js
+++ b/test/test.js
@@ -96,6 +96,20 @@ test('passes remote address', (t) => {
   })
 })
 
+test('passes a socket which emits events like a normal one does', (t) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    req.socket.on('timeout', () => {})
+    res.end('added')
+  }
+
+  inject(dispatch, { method: 'GET', url: 'http://example.com:8080/hello' }, (err, res) => {
+    t.error(err)
+    t.equal(res.payload, 'added')
+  })
+})
+
 test('includes deprecated connection on request', (t) => {
   t.plan(2)
   const dispatch = function (req, res) {


### PR DESCRIPTION
Before this change, if a Fastify user attached an `onTimeout` hook to their server, an error would be thrown in test mode when injecting requests with light-my-request

```
TypeError: request.raw.socket.on is not a function

      at Object.routeHandler [as handler] (../../node_modules/fastify/lib/route.js:350:28)
      at Router.lookup (../../node_modules/find-my-way/index.js:356:14)
      at ../../node_modules/light-my-request/index.js:101:38
      at Request.prepare (../../node_modules/light-my-request/lib/request.js:110:12)
      at ../../node_modules/light-my-request/index.js:101:11
      at doInject (../../node_modules/light-my-request/index.js:97:12)
      at Chain.<computed> [as then] (../../node_modules/light-my-request/index.js:187:23)
          at runMicrotasks (<anonymous>)
```

This fixes the socket object to have an `on` function (as well as the rest of the EventEmitter interface) so that things that add timeout handlers can at least add them without erroring. This doesn't implement actual timeout injection, but I think that could be done in userland by emitting events on the socket manually.

Similar to #99.
