### PR TITLE
fix: fix response.destroy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,6 @@ package-lock.json
 
 # generated code
 examples/typescript-server.js
-test/type/index.js 
+test/type/index.js
+
+.vscode

--- a/lib/request.js
+++ b/lib/request.js
@@ -178,10 +178,10 @@ Request.prototype.destroy = function (error) {
   this.destroyed = true
   if (error) {
     this._error = true
-    this.emit('error', error)
+    process.nextTick(() => this.emit('error', error))
   }
 
-  this.emit('close')
+  process.nextTick(() => this.emit('close'))
 }
 
 module.exports = Request

--- a/lib/request.js
+++ b/lib/request.js
@@ -174,6 +174,14 @@ Request.prototype._read = function (size) {
   })
 }
 
-Request.prototype.destroy = function () {}
+Request.prototype.destroy = function (error) {
+  this.destroyed = true
+  if (error) {
+    this._error = true
+    this.emit('error', error)
+  }
+
+  this.emit('close')
+}
 
 module.exports = Request

--- a/lib/request.js
+++ b/lib/request.js
@@ -175,7 +175,9 @@ Request.prototype._read = function (size) {
 }
 
 Request.prototype.destroy = function (error) {
+  if (this.destroyed) return
   this.destroyed = true
+
   if (error) {
     this._error = true
     process.nextTick(() => this.emit('error', error))

--- a/lib/response.js
+++ b/lib/response.js
@@ -21,7 +21,9 @@ function Response (req, onEnd, reject) {
 
   this._promiseCallback = typeof reject === 'function'
 
+  let called = false
   const onEndSuccess = (payload) => {
+    called = true
     if (this._promiseCallback) {
       return process.nextTick(() => onEnd(payload))
     }
@@ -29,6 +31,8 @@ function Response (req, onEnd, reject) {
   }
 
   const onEndFailure = (err) => {
+    if (called) return
+    called = true
     if (this._promiseCallback) {
       return process.nextTick(() => reject(err))
     }
@@ -44,6 +48,8 @@ function Response (req, onEnd, reject) {
   this.connection.once('error', onEndFailure)
 
   this.once('error', onEndFailure)
+
+  this.once('close', onEndFailure)
 }
 
 util.inherits(Response, http.ServerResponse)
@@ -91,7 +97,13 @@ Response.prototype.end = function (data, encoding, callback) {
   this.emit('finish')
 }
 
-Response.prototype.destroy = function () {}
+Response.prototype.destroy = function (error) {
+  if (error) {
+    this.emit('error', error)
+  }
+
+  this.emit('close')
+}
 
 Response.prototype.addTrailers = function (trailers) {
   for (const key in trailers) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -23,6 +23,7 @@ function Response (req, onEnd, reject) {
 
   let called = false
   const onEndSuccess = (payload) => {
+    // no need to early-return if already called because this handler is bound `once`
     called = true
     if (this._promiseCallback) {
       return process.nextTick(() => onEnd(payload))
@@ -98,11 +99,14 @@ Response.prototype.end = function (data, encoding, callback) {
 }
 
 Response.prototype.destroy = function (error) {
+  if (this.destroyed) return
+  this.destroyed = true
+
   if (error) {
-    this.emit('error', error)
+    process.nextTick(() => this.emit('error', error))
   }
 
-  this.emit('close')
+  process.nextTick(() => this.emit('close'))
 }
 
 Response.prototype.addTrailers = function (trailers) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "types": "index.d.ts",
   "devDependencies": {
     "@types/node": "^14.0.1",
+    "end-of-stream": "^1.4.4",
     "form-auto-content": "^2.0.0",
     "form-data": "^3.0.0",
     "pre-commit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "test": "npm run lint && npm run unit && npm run tsd",
     "lint": "standard",
-    "unit": "tap test/test.js --100",
+    "unit": "tap test/test.js test/*.test.js --100",
     "coverage": "npm run unit -- --cov --coverage-report=html",
     "tsd": "tsd"
   },

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -1,0 +1,15 @@
+const { test } = require('tap')
+
+const Response = require('../lib/response')
+
+test('multiple calls to res.destroy should not be called', (t) => {
+  t.plan(1)
+
+  const mockReq = {}
+  const res = new Response(mockReq, (err, response) => {
+    t.error(err)
+  })
+
+  res.destroy()
+  res.destroy()
+})

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,8 @@ const qs = require('querystring')
 const fs = require('fs')
 const zlib = require('zlib')
 const http = require('http')
+const { finished } = require('stream')
+var eos = require('end-of-stream')
 
 const inject = require('../index')
 const parseURL = require('../lib/parseURL')
@@ -1603,6 +1605,40 @@ test('request destory with error', (t) => {
 
   inject(dispatch, { method: 'GET', url: '/' }, (err, res) => {
     t.equal(err, fakeError)
+    t.equal(res, null)
+  })
+})
+
+test('compatible with stream.finished', (t) => {
+  t.plan(3)
+
+  const dispatch = function (req, res) {
+    finished(res, (err) => {
+      t.ok(err instanceof Error)
+    })
+
+    req.destroy()
+  }
+
+  inject(dispatch, { method: 'GET', url: '/' }, (err, res) => {
+    t.error(err)
+    t.equal(res, null)
+  })
+})
+
+test('compatible with eos', (t) => {
+  t.plan(3)
+
+  const dispatch = function (req, res) {
+    eos(res, (err) => {
+      t.ok(err instanceof Error)
+    })
+
+    req.destroy()
+  }
+
+  inject(dispatch, { method: 'GET', url: '/' }, (err, res) => {
+    t.error(err)
     t.equal(res, null)
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1568,6 +1568,8 @@ test('simulate invalid alter _lightMyRequest.isDone without end', (t) => {
 })
 
 test('no error for response destory', (t) => {
+  t.plan(1)
+
   const dispatch = function (req, res) {
     res.destroy()
   }
@@ -1575,6 +1577,32 @@ test('no error for response destory', (t) => {
   inject(dispatch, { method: 'GET', url: '/' }, (err, res) => {
     t.error(err)
   })
+})
 
-  t.end()
+test('request destory without error', (t) => {
+  t.plan(2)
+
+  const dispatch = function (req, res) {
+    req.destroy()
+  }
+
+  inject(dispatch, { method: 'GET', url: '/' }, (err, res) => {
+    t.error(err)
+    t.equal(res, null)
+  })
+})
+
+test('request destory with error', (t) => {
+  t.plan(2)
+
+  const fakeError = new Error('some-err')
+
+  const dispatch = function (req, res) {
+    req.destroy(fakeError)
+  }
+
+  inject(dispatch, { method: 'GET', url: '/' }, (err, res) => {
+    t.equal(err, fakeError)
+    t.equal(res, null)
+  })
 })


### PR DESCRIPTION
- Implemented the missing `Response.prototype.destroy` 
- Fixed test

The test was there for destroy, but it never failed because it didn't have `t.plan` so the test didn't make sure the `inject` response callback was ever called.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
