### PR TITLE
Fix typescript chain response

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,8 @@ declare namespace LightMyRequest {
     payload: (payload: InjectPayload) => Chain
     query: (query: object) => Chain
     cookies: (query: object) => Chain
-    end: (callback?: CallbackFunc) => Promise<Response>
+    end(): Promise<Response>
+    end(callback: CallbackFunc): void
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,15 +86,15 @@ declare namespace LightMyRequest {
     cookies: Array<object>
   }
 
-  interface Chain {
-    delete: (url: string) => Chain | Promise<Response>
-    get: (url: string) => Chain | Promise<Response>
-    head: (url: string) => Chain | Promise<Response>
-    options: (url: string) => Chain | Promise<Response>
-    patch: (url: string) => Chain | Promise<Response>
-    post: (url: string) => Chain | Promise<Response>
-    put: (url: string) => Chain | Promise<Response>
-    trace: (url: string) => Chain | Promise<Response>
+  interface Chain extends Promise<Response> {
+    delete: (url: string) => Chain
+    get: (url: string) => Chain
+    head: (url: string) => Chain
+    options: (url: string) => Chain
+    patch: (url: string) => Chain
+    post: (url: string) => Chain
+    put: (url: string) => Chain
+    trace: (url: string) => Chain
     body: (body: InjectPayload) => Chain
     headers: (headers: http.IncomingHttpHeaders | http.OutgoingHttpHeaders) => Chain
     payload: (payload: InjectPayload) => Chain

--- a/index.d.ts
+++ b/index.d.ts
@@ -87,14 +87,14 @@ declare namespace LightMyRequest {
   }
 
   interface Chain {
-    delete: (url: string) => Chain
-    get: (url: string) => Chain
-    head: (url: string) => Chain
-    options: (url: string) => Chain
-    patch: (url: string) => Chain
-    post: (url: string) => Chain
-    put: (url: string) => Chain
-    trace: (url: string) => Chain
+    delete: (url: string) => Chain | Promise<Response>
+    get: (url: string) => Chain | Promise<Response>
+    head: (url: string) => Chain | Promise<Response>
+    options: (url: string) => Chain | Promise<Response>
+    patch: (url: string) => Chain | Promise<Response>
+    post: (url: string) => Chain | Promise<Response>
+    put: (url: string) => Chain | Promise<Response>
+    trace: (url: string) => Chain | Promise<Response>
     body: (body: InjectPayload) => Chain
     headers: (headers: http.IncomingHttpHeaders | http.OutgoingHttpHeaders) => Chain
     payload: (payload: InjectPayload) => Chain

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -1,7 +1,7 @@
 'use strict'
 
 function asyncAwaitTest (t, inject) {
-  t.plan(3)
+  t.plan(4)
 
   t.test('basic async await', async t => {
     const dispatch = function (req, res) {
@@ -39,6 +39,20 @@ function asyncAwaitTest (t, inject) {
     try {
       const chain = inject(dispatch).get('http://example.com:8080/hello')
       const res = await chain.end()
+      t.equal(res.payload, 'hello')
+    } catch (err) {
+      t.fail(err)
+    }
+  })
+
+  t.test('chainable api with async await without end()', async t => {
+    const dispatch = function (req, res) {
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
+      res.end('hello')
+    }
+
+    try {
+      const res = await inject(dispatch).get('http://example.com:8080/hello')
       t.equal(res.payload, 'hello')
     } catch (err) {
       t.fail(err)

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -58,13 +58,15 @@ inject(dispatch, { method: 'get', url: '/', query: { name1: ['value1', 'value2']
   expectResponse(res)
 })
 
-inject(dispatch)
-  .get('/')
-  .end((err, res) => {
-    expectType<Error>(err)
-    expectType<Response>(res)
-    console.log(res.payload)
-  })
+expectType<void>(
+  inject(dispatch)
+    .get('/')
+    .end((err, res) => {
+      expectType<Error>(err)
+      expectType<Response>(res)
+      console.log(res.payload)
+    })
+)
 
 inject(dispatch)
   .get('/')

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -66,6 +66,12 @@ inject(dispatch)
     console.log(res.payload)
   })
 
+inject(dispatch)
+  .get('/')
+  .then((value) => {
+    expectType<Response>(value)
+  })
+
 expectType<Chain>(inject(dispatch))
 expectType<Promise<Response>>(inject(dispatch).end())
 expectType<Chain>(inject(dispatch, { method: 'get', url: '/' }))

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ const zlib = require('zlib')
 const http = require('http')
 const { finished } = require('stream')
 const eos = require('end-of-stream')
+const semver = require('semver')
 
 const inject = require('../index')
 const parseURL = require('../lib/parseURL')
@@ -845,7 +846,7 @@ test('promises support', (t) => {
 })
 
 test('async wait support', t => {
-  if (Number(process.versions.node[0]) >= 8) {
+  if (semver.gt(process.versions.node, '8.0.0')) {
     require('./async-await')(t, inject)
   } else {
     t.pass('Skip because Node version < 8')


### PR DESCRIPTION
ref: #109 

On my local the following assertion is not valid:
```js
Number(process.versions.node[0]) >= 8 // it returns 1 for node v12.18.3
```
So, changed to `semver` check to prevent bugs

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
