### PR TITLE
chore: add failing test for send payload

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1706,3 +1706,19 @@ test('passes headers when using an express app', (t) => {
     t.equal(res.headers['some-fancy-header'], 'a very cool value')
   })
 })
+
+test("passes payload when using express' send", (t) => {
+  t.plan(3)
+
+  const app = express()
+
+  app.get('/hello', (req, res) => {
+    res.send('some text')
+  })
+
+  inject(app, { method: 'GET', url: 'http://example.com:8080/hello' }, (err, res) => {
+    t.error(err)
+    t.equal(res.headers['content-length'], '9')
+    t.equal(res.payload, 'some text')
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

When using Express' [`res.send`](http://expressjs.com/en/api.html#res.send), `payload` from `light-my-request` is set to an empty string rather then the value passed.

This is just a failing test as I don't know how to fix it. Pointers very much welcome!

From my debugging:

For some reason, https://github.com/fastify/light-my-request/blob/52dd662a177696bc0e92f56e849665c8d854c961/lib/response.js#L83 is not called.

We end up in express here: https://github.com/expressjs/express/blob/06d11755c99fe4c1cddf8b889a687448b568472d/lib/response.js#L221, which calls https://github.com/nodejs/node/blob/7ca38f05a023666274569343f128c5aed81599f3/lib/_http_outgoing.js#L830, but `light-my-request`'s `Reponse.end` is not invoked, so the `payload` is not correct