### PR TITLE
fixed parseURL and all tests passed for bug: Value of request.url when using .inject differs from a real server #3257

### DIFF
--- a/lib/parseURL.js
+++ b/lib/parseURL.js
@@ -12,6 +12,9 @@ const BASE_URL = 'http://localhost'
  * @return {URL}
  */
 module.exports = function parseURL (url, query) {
+  if ((typeof url === 'string' || Object.prototype.toString.call(url) === '[object String]') && url.startsWith('//')) {
+    url = BASE_URL + url
+  }
   const result = typeof url === 'object'
     ? Object.assign(new URL(BASE_URL), url)
     : new URL(url, BASE_URL)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "ajv": "^8.1.0",
     "cookie": "^0.4.0",
+    "fastify": "^3.20.2",
     "fastify-warning": "^0.2.0",
     "readable-stream": "^3.6.0",
     "set-cookie-parser": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "ajv": "^8.1.0",
     "cookie": "^0.4.0",
-    "fastify": "^3.20.2",
     "fastify-warning": "^0.2.0",
     "readable-stream": "^3.6.0",
     "set-cookie-parser": "^2.4.1"

--- a/test/test.js
+++ b/test/test.js
@@ -11,14 +11,12 @@ const { finished } = require('stream')
 const eos = require('end-of-stream')
 const semver = require('semver')
 const express = require('express')
-const fastify = require('fastify')
 
 const inject = require('../index')
 const parseURL = require('../lib/parseURL')
 
 const FormData = require('form-data')
 const formAutoContent = require('form-auto-content')
-
 const httpMethods = [
   'delete',
   'get',
@@ -1708,18 +1706,18 @@ test('passes headers when using an express app', (t) => {
   })
 })
 
-test('value of request url when using inject should not differ', async (t) => {
+test('value of request url when using inject should not differ', (t) => {
   t.plan(1)
-  const ap = fastify()
-  ap.get('*', function (request, reply) {
-    reply.send({ url: request.url })
-  })
-  const res = await ap.inject({
-    method: 'GET',
-    url: 'http://example.com:8080//foo'
-  })
-  const v = JSON.parse((res.body)) // added this Json parse
-  t.equal(v.url, '//foo')
+
+  const server = http.createServer()
+
+  const dispatch = function (req, res) {
+    res.end(req.url)
+  }
+
+  inject(dispatch, { method: 'GET', url: 'http://example.com:8080//hello', server: server })
+    .then(res => { t.equal(res.body, '//hello') })
+    .catch(err => t.error(err))
 })
 
 test('Can parse paths with single leading slash', (t) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
