### PR TITLE
added rawHeaders to Request

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,7 @@ declare namespace LightMyRequest {
     httpVersion: string
     method: HTTPMethods
     headers: http.IncomingHttpHeaders
+    rawHeaders: string[]
     prepare: (next: () => void) => void
     // @deprecated
     connection: object

--- a/lib/request.js
+++ b/lib/request.js
@@ -63,6 +63,7 @@ function Request (options) {
   this.method = options.method ? options.method.toUpperCase() : 'GET'
 
   this.headers = {}
+  this.rawHeaders = []
   const headers = options.headers || {}
 
   for (const field in headers) {
@@ -105,6 +106,10 @@ function Request (options) {
   // Set the content-length for the corresponding payload if none set
   if (payload && !payloadResume && !this.headers.hasOwnProperty('content-length')) {
     this.headers['content-length'] = (Buffer.isBuffer(payload) ? payload.length : Buffer.byteLength(payload)).toString()
+  }
+
+  for (const header of Object.keys(this.headers)) {
+    this.rawHeaders.push(header, this.headers[header])
   }
 
   // Use _lightMyRequest namespace to avoid collision with Node

--- a/test/test.js
+++ b/test/test.js
@@ -87,15 +87,16 @@ test('passes headers', (t) => {
 })
 
 test('request has rawHeaders', (t) => {
-  t.plan(2)
+  t.plan(3)
   const dispatch = function (req, res) {
-    res.writeHead(200, { 'Content-Type': 'text/plain' })
-    res.end(req.rawHeaders.toString())
+    t.ok(Array.isArray(req.rawHeaders))
+    t.match(req.rawHeaders, ['super', 'duper', 'user-agent', 'lightMyRequest', 'host', 'example.com:8080'])
+    res.writeHead(200)
+    res.end()
   }
 
   inject(dispatch, { method: 'GET', url: 'http://example.com:8080/hello', headers: { Super: 'duper' } }, (err, res) => {
     t.error(err)
-    t.equal(res.payload, 'super,duper,user-agent,lightMyRequest,host,example.com:8080')
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -86,6 +86,19 @@ test('passes headers', (t) => {
   })
 })
 
+test('request has rawHeaders', (t) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end(req.rawHeaders.toString())
+  }
+
+  inject(dispatch, { method: 'GET', url: 'http://example.com:8080/hello', headers: { Super: 'duper' } }, (err, res) => {
+    t.error(err)
+    t.equal(res.payload, 'super,duper,user-agent,lightMyRequest,host,example.com:8080')
+  })
+})
+
 test('passes remote address', (t) => {
   t.plan(2)
   const dispatch = function (req, res) {


### PR DESCRIPTION
I've noticed that Request does not contain rawHeaders property when I was unable to test proxy example from undici repository, see here: https://github.com/nodejs/undici/blob/main/examples/proxy/proxy.js#L9

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
