### PR TITLE
Dropped readable-stream dependency

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -2,7 +2,7 @@
 
 /* eslint no-prototype-builtins: 0 */
 
-const { Readable } = require('readable-stream')
+const { Readable } = require('stream')
 const util = require('util')
 const cookie = require('cookie')
 const assert = require('assert')
@@ -53,7 +53,9 @@ class MockSocket extends EventEmitter {
  * @param {any} [options.payload]
  */
 function Request (options) {
-  Readable.call(this)
+  Readable.call(this, {
+    autoDestroy: false
+  })
 
   const parsedURL = parseURL(options.url || options.path, options.query)
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const http = require('http')
-const { Writable } = require('readable-stream')
+const { Writable } = require('stream')
 const util = require('util')
 
 const setCookie = require('set-cookie-parser')

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "ajv": "^8.1.0",
     "cookie": "^0.4.0",
     "fastify-warning": "^0.2.0",
-    "readable-stream": "^3.6.0",
     "set-cookie-parser": "^2.4.1"
   },
   "types": "index.d.ts",

--- a/test/test.js
+++ b/test/test.js
@@ -2,12 +2,11 @@
 
 const t = require('tap')
 const test = t.test
-const { Readable } = require('readable-stream')
+const { Readable, finished } = require('stream')
 const qs = require('querystring')
 const fs = require('fs')
 const zlib = require('zlib')
 const http = require('http')
-const { finished } = require('stream')
 const eos = require('end-of-stream')
 const semver = require('semver')
 const express = require('express')
@@ -127,7 +126,7 @@ test('passes a socket which emits events like a normal one does', (t) => {
   })
 })
 
-test('includes deprecated connection on request', { only: true }, (t) => {
+test('includes deprecated connection on request', (t) => {
   t.plan(3)
   const warnings = process.listeners('warning')
   process.removeAllListeners('warning')


### PR DESCRIPTION
It's not really needed and it's just more dependencies that we are bringing along.

See https://github.com/fastify/fastify/issues/3371

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
