### PR TITLE
Correctly support finished in Node v16

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -86,7 +86,13 @@ Response.prototype.end = function (data, encoding, callback) {
   }
 
   http.ServerResponse.prototype.end.call(this, callback)
+
   this.emit('finish')
+
+  // We need to emit 'close' otherwise stream.finished() would
+  // not pick it up on Node v16
+
+  this.destroy()
 }
 
 Response.prototype.destroy = function (error) {

--- a/test/test.js
+++ b/test/test.js
@@ -1670,6 +1670,28 @@ test('compatible with eos', (t) => {
   })
 })
 
+test('compatible with stream.finished pipe a Stream', (t) => {
+  t.plan(3)
+
+  const dispatch = function (req, res) {
+    finished(res, (err) => {
+      t.error(err)
+    })
+
+    new Readable({
+      read () {
+        this.push('hello world')
+        this.push(null)
+      }
+    }).pipe(res)
+  }
+
+  inject(dispatch, { method: 'GET', url: '/' }, (err, res) => {
+    t.error(err)
+    t.equal(res.body, 'hello world')
+  })
+})
+
 test('compatible with eos, passes error correctly', (t) => {
   t.plan(3)
 


### PR DESCRIPTION
Unfortunately using this together with `stream.finished()` did not work as expected in Node v16.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
