### PR TITLE
fix: use correct object when calling `json`

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -144,7 +144,7 @@ function generatePayload (response) {
     if (res.headers['content-type'].indexOf('application/json') < 0) {
       throw new Error('The content-type of the response is not application/json')
     }
-    return JSON.parse(this.payload)
+    return JSON.parse(res.payload)
   }
 
   return res


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

There's already a test for this, so I'm not sure what's going on.

Failing test case using fastify:

```js
import Fastify from 'fastify';

const app = Fastify();

const schema = {
  type: 'object',
  properties: { severity: { type: 'string' } },
  required: ['severity'],
};

app.get('/', { schema: { querystring: schema } }, async () => ({ foo: 'bar' }));

const { json } = await app.inject('/');

console.log(json());
```

```
TypeError: Cannot read properties of undefined (reading 'payload')
    at parseJsonPayload (/Users/simen/repos/light-my-request/node_modules/light-my-request/lib/response.js:147:28)
```

The diff in this PR fixes it