### PR TITLE
feat: add support for custom request types

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Injects a fake request into an HTTP server.
   - `server` - Optional http server. It is used for binding the `dispatchFunc`.
   - `autoStart` - Automatically start the request as soon as the method
     is called. It is only valid when not passing a callback. Defaults to `true`.
+  - `customRequestType` - Optional type from which the `request` object should
+    inherit besides `stream.Readable`
 - `callback` - the callback function using the signature `function (err, res)` where:
   - `err` - error object
   - `res` - a response object where:

--- a/lib/request.js
+++ b/lib/request.js
@@ -50,6 +50,7 @@ class MockSocket extends EventEmitter {
  * @param {Object} [options.cookies]
  * @param {Object} [options.headers]
  * @param {Object} [options.query]
+ * @param {Object} [options.customRequestType]
  * @param {any} [options.payload]
  */
 function Request (options) {
@@ -119,6 +120,10 @@ function Request (options) {
     payload,
     isDone: false,
     simulate: options.simulate || {}
+  }
+
+  if (options.customRequestType) {
+    util.inherits(this.constructor, options.customRequestType)
   }
 
   return this

--- a/test/test.js
+++ b/test/test.js
@@ -99,6 +99,19 @@ test('request has rawHeaders', (t) => {
   })
 })
 
+test('request has custom type', (t) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    t.ok(req instanceof http.IncomingMessage)
+    res.writeHead(200)
+    res.end()
+  }
+
+  inject(dispatch, { method: 'GET', url: 'http://example.com:8080/hello', customRequestType: http.IncomingMessage }, (err, res) => {
+    t.error(err)
+  })
+})
+
 test('passes remote address', (t) => {
   t.plan(2)
   const dispatch = function (req, res) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR adds support for a new `option` parameter: `customRequestType`. It represents a custom type from which the `request` object should inherit besides `stream.Readable`.

Closes https://github.com/fastify/light-my-request/issues/189.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
