### PR TITLE
fix: fix custom request instantiation

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -54,13 +54,14 @@ class MockSocket extends EventEmitter {
  * @param {any} [options.payload]
  */
 function CustomRequest (options) {
-  return new _CustomLMRRequest()
+  return new _CustomLMRRequest(this)
 
-  function _CustomLMRRequest () {
-    Request.call(this, {
+  function _CustomLMRRequest (obj) {
+    Request.call(obj, {
       ...options,
       Request: undefined
     })
+    Object.assign(this, obj)
 
     for (const fn of Object.keys(Request.prototype)) {
       this.constructor.prototype[fn] = Request.prototype[fn]

--- a/test/test.js
+++ b/test/test.js
@@ -112,6 +112,19 @@ test('request inherits from custom class', (t) => {
   })
 })
 
+test('request with custom class preserves stream data', (t) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    t.ok(req._readableState)
+    res.writeHead(200)
+    res.end()
+  }
+
+  inject(dispatch, { method: 'GET', url: 'http://example.com:8080/hello', Request: http.IncomingMessage }, (err, res) => {
+    t.error(err)
+  })
+})
+
 test('assert Request option has a valid prototype', (t) => {
   t.plan(2)
   const dispatch = function (req, res) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Custom requests should preserve the stream attributes of the request,
namely the `_readableState` property inherited from `Readable`.

A new test to specifically check this issue has been added as well.

This is a patch to the feature introduced in #190.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
