### PR TITLE
Add failing test for a plain node http dispatch function

### DIFF
--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -90,3 +90,17 @@ const parsedValueUsingGeneric = response.json<ParsedValue>()
 expectType<ParsedValue>(parsedValueUsingGeneric)
 
 expectNotAssignable<http.ServerResponse>(response)
+
+const httpDispatch = function (req: http.IncomingMessage, res: http.ServerResponse) {
+  expectType<boolean>(isInjection(req))
+  expectType<boolean>(isInjection(res))
+
+  const reply = 'Hello World'
+  res.writeHead(200, { 'Content-Type': 'text/plain', 'Content-Length': reply.length })
+  res.end(reply)
+}
+
+inject(httpDispatch, { method: 'get', url: '/' }, (err, res) => {
+  expectType<Error>(err)
+  expectResponse(res)
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This is just a failing test for #201, I'm not sure how to fix this, and a fix might be a breaking change in the typings. We seem to have both some variance (Damn I hate variance, so confusing...) issue where TypeScript seems to require `Request` to specify all props of `http.IncomingMessage` for `DispatchFunc` and also mismatches in types between `Request` and `http.IncomingMessage`, such as the `prepare` callback, `url` can be undefined, `methods` is just a `string | undefined` in `http.IncomingMessage` and so on.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
