### PR TITLE
fix: pass req to ServerResponse to support pipeline() on node 16

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -94,6 +94,8 @@ function Request (options) {
 
   this.url = parsedURL.pathname + parsedURL.search
 
+  this.httpVersionMajor = 1
+  this.httpVersionMinor = 1
   this.httpVersion = '1.1'
   this.method = options.method ? options.method.toUpperCase() : 'GET'
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -7,11 +7,7 @@ const util = require('util')
 const setCookie = require('set-cookie-parser')
 
 function Response (req, onEnd, reject) {
-  http.ServerResponse.call(this, {
-    method: req.method,
-    httpVersionMajor: 1,
-    httpVersionMinor: 1
-  })
+  http.ServerResponse.call(this, req)
 
   this._lightMyRequest = { headers: null, trailers: {}, payloadChunks: [] }
   // This forces node@8 to always render the headers


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Close #212 

Pass the real req to ServerResponse, then it can be used with pipeline().

* https://github.com/nodejs/node/blob/96601cc759aa6f54f9cf9db466a004cb57ede651/lib/_http_server.js
* https://github.com/nodejs/node/blob/96601cc759aa6f54f9cf9db466a004cb57ede651/lib/internal/streams/end-of-stream.js

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
