### PR TITLE
fix: Response.json() should not check the content-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Injects a fake request into an HTTP server.
     - `body` - alias for payload.
     - `rawPayload` - the raw payload as a Buffer.
     - `trailers` - an object containing the response trailers.
-    - `json` - a function that parses a json response payload and returns an object. Throws if the content type is not `application/json`, or a related media type.
+    - `json` - a function that parses a json response payload and returns an object.
     - `cookies` - a getter that parses the `set-cookie` response header and returns an array with all the cookies and their metadata.
 
 Notes:

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Injects a fake request into an HTTP server.
     - `body` - alias for payload.
     - `rawPayload` - the raw payload as a Buffer.
     - `trailers` - an object containing the response trailers.
-    - `json` - a function that parses the `application/json` response payload and returns an object. Throws if the content type does not contain `application/json`.
+    - `json` - a function that parses a json response payload and returns an object. Throws if the content type is not `application/json`, or a related media type.
     - `cookies` - a getter that parses the `set-cookie` response header and returns an array with all the cookies and their metadata.
 
 Notes:

--- a/lib/response.js
+++ b/lib/response.js
@@ -139,8 +139,8 @@ function generatePayload (response) {
 
   // Prepare payload parsers
   res.json = function parseJsonPayload () {
-    if (res.headers['content-type'].indexOf('application/json') < 0) {
-      throw new Error('The content-type of the response is not application/json')
+    if (!/^application\/(?<tree>([\w-]*\.)*)(?<subtype>[\w-]*\+)?json(.*)$/.test(res.headers['content-type'])) {
+      throw new Error('The content-type of the response is not application/json or a related media type')
     }
     return JSON.parse(res.payload)
   }

--- a/lib/response.js
+++ b/lib/response.js
@@ -139,9 +139,6 @@ function generatePayload (response) {
 
   // Prepare payload parsers
   res.json = function parseJsonPayload () {
-    if (!/^application\/(?<tree>([\w-]*\.)*)(?<subtype>[\w-]*\+)?json(.*)$/.test(res.headers['content-type'])) {
-      throw new Error('The content-type of the response is not application/json or a related media type')
-    }
     return JSON.parse(res.payload)
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1421,55 +1421,16 @@ test('Response.json() should parse the JSON payload', (t) => {
   })
 })
 
-test('Response.json() should throw an error if content-type is not application/json', (t) => {
+test('Response.json() should not throw an error if content-type is not application/json', (t) => {
   t.plan(2)
 
-  const json = {
+  const jsonData = {
     a: 1,
     b: '2'
   }
 
   const dispatch = function (req, res) {
     res.writeHead(200, { 'Content-Type': 'text/plain' })
-    res.end(JSON.stringify(json))
-  }
-
-  inject(dispatch, { method: 'GET', path: 'http://example.com:8080/hello' }, (err, res) => {
-    t.error(err)
-    t.throws(res.json, Error)
-  })
-})
-
-test('Response.json() should not throw an error if content-type is a subtype of application/json', (t) => {
-  t.plan(2)
-
-  const jsonData = {
-    a: 1,
-    b: '2'
-  }
-
-  const dispatch = function (req, res) {
-    res.writeHead(200, { 'Content-Type': 'application/expect-ct-report+json' })
-    res.end(JSON.stringify(jsonData))
-  }
-
-  inject(dispatch, { method: 'GET', path: 'http://example.com:8080/hello' }, (err, res) => {
-    t.error(err)
-    const { json } = res
-    t.same(json(), jsonData)
-  })
-})
-
-test('Response.json() should not throw an error if content-type is application/tree.subtype+json', (t) => {
-  t.plan(2)
-
-  const jsonData = {
-    a: 1,
-    b: '2'
-  }
-
-  const dispatch = function (req, res) {
-    res.writeHead(200, { 'Content-Type': 'application/vnd.apothekende.reservation+json' })
     res.end(JSON.stringify(jsonData))
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1440,6 +1440,46 @@ test('Response.json() should throw an error if content-type is not application/j
   })
 })
 
+test('Response.json() should not throw an error if content-type is a subtype of application/json', (t) => {
+  t.plan(2)
+
+  const jsonData = {
+    a: 1,
+    b: '2'
+  }
+
+  const dispatch = function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'application/expect-ct-report+json' })
+    res.end(JSON.stringify(jsonData))
+  }
+
+  inject(dispatch, { method: 'GET', path: 'http://example.com:8080/hello' }, (err, res) => {
+    t.error(err)
+    const { json } = res
+    t.same(json(), jsonData)
+  })
+})
+
+test('Response.json() should not throw an error if content-type is application/tree.subtype+json', (t) => {
+  t.plan(2)
+
+  const jsonData = {
+    a: 1,
+    b: '2'
+  }
+
+  const dispatch = function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'application/vnd.apothekende.reservation+json' })
+    res.end(JSON.stringify(jsonData))
+  }
+
+  inject(dispatch, { method: 'GET', path: 'http://example.com:8080/hello' }, (err, res) => {
+    t.error(err)
+    const { json } = res
+    t.same(json(), jsonData)
+  })
+})
+
 test('Response.json() should throw an error if the payload is not of valid JSON format', (t) => {
   t.plan(2)
 


### PR DESCRIPTION
Closes #228 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
