### PR TITLE
#235 Add fake origin header

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -123,6 +123,9 @@ function Request (options) {
   if (('user-agent' in this.headers) === false) {
     this.headers['user-agent'] = 'lightMyRequest'
   }
+  if (('origin' in this.headers) === false) {
+    this.headers.origin = 'http://example.com:8080'
+  }
   this.headers.host = this.headers.host || options.authority || hostHeaderFromURL(parsedURL)
 
   if (options.cookies) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -105,9 +105,9 @@ test('leave intact original origin header', (t) => {
     res.end(req.headers.origin)
   }
 
-  inject(dispatch, { method: 'GET', url: 'http://example.com:8080/hello', headers: { origin: 'https://example.com' } }, (err, res) => {
+  inject(dispatch, { method: 'GET', url: 'http://example.com:8080/hello', headers: { origin: 'https://lightmyrequest' } }, (err, res) => {
     t.error(err)
-    t.equal(res.payload, 'https://example.com')
+    t.equal(res.payload, 'https://lightmyrequest')
   })
 })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -85,11 +85,37 @@ test('passes headers', (t) => {
   })
 })
 
+test('passes fake origin header', (t) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end(req.headers.origin)
+  }
+
+  inject(dispatch, { method: 'GET', url: 'http://example.com:8080/hello' }, (err, res) => {
+    t.error(err)
+    t.equal(res.payload, 'http://example.com:8080')
+  })
+})
+
+test('leave intact original origin header', (t) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end(req.headers.origin)
+  }
+
+  inject(dispatch, { method: 'GET', url: 'http://example.com:8080/hello', headers: { origin: 'https://example.com' } }, (err, res) => {
+    t.error(err)
+    t.equal(res.payload, 'https://example.com')
+  })
+})
+
 test('request has rawHeaders', (t) => {
   t.plan(3)
   const dispatch = function (req, res) {
     t.ok(Array.isArray(req.rawHeaders))
-    t.match(req.rawHeaders, ['super', 'duper', 'user-agent', 'lightMyRequest', 'host', 'example.com:8080'])
+    t.match(req.rawHeaders, ['super', 'duper', 'user-agent', 'lightMyRequest', 'origin', 'http://example.com:8080', 'host', 'example.com:8080'])
     res.writeHead(200)
     res.end()
   }
@@ -1615,6 +1641,7 @@ test('correctly handles no string headers', (t) => {
       true: 'true',
       false: 'false',
       host: 'example.com:8080',
+      origin: 'http://example.com:8080',
       'user-agent': 'lightMyRequest'
     })
   })


### PR DESCRIPTION
Adding fake origin header as per #235

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
