### PR TITLE
fix: add missing type for request body

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -52,6 +52,7 @@ declare namespace inject {
     method?: HTTPMethods
     validate?: boolean
     payload?: InjectPayload
+    body?: InjectPayload
     server?: http.Server
     cookies?: { [k: string]: string },
     signal?: AbortSignal,

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -21,6 +21,8 @@ const expectResponse = function (res: Response) {
   expectAssignable<Function>(res.json)
   expectAssignable<http.ServerResponse>(res.raw.res)
   expectAssignable<http.IncomingMessage>(res.raw.req)
+  expectType<string>(res.payload)
+  expectType<string>(res.body)
   expectAssignable<Array<any>>(res.cookies)
   const cookie = res.cookies[0]
   expectType<string>(cookie.name)
@@ -70,6 +72,16 @@ inject(dispatch, { method: 'get', url: '/', query: { name1: ['value1', 'value2']
 })
 
 inject(dispatch, { method: 'get', url: '/', query: 'name1=value1' }, (err, res) => {
+  expectType<Error>(err)
+  expectResponse(res)
+})
+
+inject(dispatch, { method: 'post', url: '/', payload: { name1: 'value1', value2: 'value2' } }, (err, res) => {
+  expectType<Error>(err)
+  expectResponse(res)
+})
+
+inject(dispatch, { method: 'post', url: '/', body: { name1: 'value1', value2: 'value2' } }, (err, res) => {
   expectType<Error>(err)
   expectResponse(res)
 })


### PR DESCRIPTION
`body` is an alias for `payload`, but was missing from the types.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
