### PR TITLE
Calling req.destroy() after reading the whole payload should not error

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -144,12 +144,6 @@ function Request (options) {
     configurable: true
   })
 
-  const signal = options.signal
-  /* istanbul ignore if  */
-  if (signal) {
-    addAbortSignal(signal, this)
-  }
-
   // we keep both payload and body for compatibility reasons
   let payload = options.payload || options.body || null
   const payloadResume = payload && typeof payload.resume === 'function'
@@ -176,6 +170,12 @@ function Request (options) {
     payload,
     isDone: false,
     simulate: options.simulate || {}
+  }
+
+  const signal = options.signal
+  /* istanbul ignore if  */
+  if (signal) {
+    addAbortSignal(signal, this)
   }
 
   return this
@@ -243,7 +243,7 @@ Request.prototype._read = function (size) {
 }
 
 Request.prototype.destroy = function (error) {
-  if (this.destroyed) return
+  if (this.destroyed || this._lightMyRequest.isDone) return
   this.destroyed = true
 
   if (error) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1966,3 +1966,23 @@ test("passes payload when using express' send", (t) => {
     t.equal(res.payload, 'some text')
   })
 })
+
+test('request that is destroyed does not error', (t) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    readStream(req, (buff) => {
+      req.destroy() // this should be a no-op
+      setImmediate(() => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end(buff)
+      })
+    })
+  }
+
+  const payload = getTestStream()
+
+  inject(dispatch, { method: 'POST', url: '/', payload }, (err, res) => {
+    t.error(err)
+    t.equal(res.payload, 'hi')
+  })
+})


### PR DESCRIPTION
This change prevents an unwanted `undefined` error when using this in combination with fastify-http-proxy: https://github.com/fastify/fastify-http-proxy/pull/305

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
