### PR TITLE
Parsing socket

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -28,6 +28,7 @@ const mockCustomReq = {
   },
   Request: http.IncomingMessage
 }
+
 const mockReqCookies = {
   url: 'http://localhost',
   method: 'GET',
@@ -59,7 +60,7 @@ suite
     new Request(mockReq) // eslint-disable-line no-new
   })
   .add('Custom Request', function () {
-    new Request.CustomRequest(mockCustomReq) // eslint-disable-line no-new
+    new (Request.getCustomRequest(mockCustomReq.Request))(mockCustomReq) // eslint-disable-line no-new
   })
   .add('Request With Cookies', function () {
     new Request(mockReqCookies) // eslint-disable-line no-new

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -5,7 +5,7 @@ const http = require('http')
 const Benchmark = require('benchmark')
 const suite = new Benchmark.Suite()
 const Request = require('../lib/request')
-const parseURL = require('../lib/parseURL')
+const parseURL = require('../lib/parse-url')
 
 const mockReq = {
   url: 'http://localhost',

--- a/index.js
+++ b/index.js
@@ -1,12 +1,9 @@
 'use strict'
 
-const assert = require('assert')
 const Request = require('./lib/request')
-const Response = require('./lib/response')
-
-const errorMessage = 'The dispatch function has already been invoked'
-
-const optsValidator = require('./lib/config-validator')
+const { Response } = require('./lib/response')
+const Chain = require('./lib/chain')
+const doInject = require('./lib/do-inject')
 
 function inject (dispatchFunc, options, callback) {
   if (typeof callback === 'undefined') {
@@ -15,143 +12,6 @@ function inject (dispatchFunc, options, callback) {
     return doInject(dispatchFunc, options, callback)
   }
 }
-
-function makeRequest (dispatchFunc, server, req, res) {
-  req.once('error', function (err) {
-    if (this.destroyed) res.destroy(err)
-  })
-
-  req.once('close', function () {
-    if (this.destroyed && !this._error) res.destroy()
-  })
-
-  return req.prepare(() => dispatchFunc.call(server, req, res))
-}
-
-function doInject (dispatchFunc, options, callback) {
-  options = (typeof options === 'string' ? { url: options } : options)
-
-  if (options.validate !== false) {
-    assert(typeof dispatchFunc === 'function', 'dispatchFunc should be a function')
-    const isOptionValid = optsValidator(options)
-    if (!isOptionValid) {
-      throw new Error(optsValidator.errors.map(e => e.message))
-    }
-  }
-
-  const server = options.server || {}
-
-  const RequestConstructor = options.Request
-    ? Request.CustomRequest
-    : Request
-
-  // Express.js detection
-  if (dispatchFunc.request && dispatchFunc.request.app === dispatchFunc) {
-    Object.setPrototypeOf(Object.getPrototypeOf(dispatchFunc.request), RequestConstructor.prototype)
-    Object.setPrototypeOf(Object.getPrototypeOf(dispatchFunc.response), Response.prototype)
-  }
-
-  if (typeof callback === 'function') {
-    const req = new RequestConstructor(options)
-    const res = new Response(req, callback)
-
-    return makeRequest(dispatchFunc, server, req, res)
-  } else {
-    return new Promise((resolve, reject) => {
-      const req = new RequestConstructor(options)
-      const res = new Response(req, resolve, reject)
-
-      makeRequest(dispatchFunc, server, req, res)
-    })
-  }
-}
-
-function Chain (dispatch, option) {
-  if (typeof option === 'string') {
-    this.option = { url: option }
-  } else {
-    this.option = Object.assign({}, option)
-  }
-
-  this.dispatch = dispatch
-  this._hasInvoked = false
-  this._promise = null
-
-  if (this.option.autoStart !== false) {
-    process.nextTick(() => {
-      if (!this._hasInvoked) {
-        this.end()
-      }
-    })
-  }
-}
-
-const httpMethods = [
-  'delete',
-  'get',
-  'head',
-  'options',
-  'patch',
-  'post',
-  'put',
-  'trace'
-]
-
-httpMethods.forEach(method => {
-  Chain.prototype[method] = function (url) {
-    if (this._hasInvoked === true || this._promise) {
-      throw new Error(errorMessage)
-    }
-    this.option.url = url
-    this.option.method = method.toUpperCase()
-    return this
-  }
-})
-
-const chainMethods = [
-  'body',
-  'cookies',
-  'headers',
-  'payload',
-  'query'
-]
-
-chainMethods.forEach(method => {
-  Chain.prototype[method] = function (value) {
-    if (this._hasInvoked === true || this._promise) {
-      throw new Error(errorMessage)
-    }
-    this.option[method] = value
-    return this
-  }
-})
-
-Chain.prototype.end = function (callback) {
-  if (this._hasInvoked === true || this._promise) {
-    throw new Error(errorMessage)
-  }
-  this._hasInvoked = true
-  if (typeof callback === 'function') {
-    doInject(this.dispatch, this.option, callback)
-  } else {
-    this._promise = doInject(this.dispatch, this.option)
-    return this._promise
-  }
-}
-
-Object.getOwnPropertyNames(Promise.prototype).forEach(method => {
-  if (method === 'constructor') return
-  Chain.prototype[method] = function (...args) {
-    if (!this._promise) {
-      if (this._hasInvoked === true) {
-        throw new Error(errorMessage)
-      }
-      this._hasInvoked = true
-      this._promise = doInject(this.dispatch, this.option)
-    }
-    return this._promise[method](...args)
-  }
-})
 
 function isInjection (obj) {
   return (
@@ -165,3 +25,7 @@ module.exports = inject
 module.exports.default = inject
 module.exports.inject = inject
 module.exports.isInjection = isInjection
+module.exports.errors = {
+  ...Request.errors,
+  ...Response.errors
+}

--- a/lib/chain.js
+++ b/lib/chain.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const doInject = require('./do-inject')
+
+const errorMessage = 'The dispatch function has already been invoked'
+
+class Chain {
+  _hasInvoked = false
+  _promise = null
+  option
+  dispatch
+
+  constructor (dispatch, option) {
+    this.dispatch = dispatch
+    if (typeof option === 'string') {
+      this.option = { url: option }
+    } else {
+      this.option = Object.assign({}, option)
+    }
+
+    if (this.option.autoStart !== false) {
+      process.nextTick(() => {
+        if (!this._hasInvoked) {
+          this.end()
+        }
+      })
+    }
+  }
+
+  /**
+   * @private
+   * @param {string} method
+   * @param {string} url
+   */
+  wrapHttpMethod (method, url) {
+    if (this._hasInvoked === true || this._promise) {
+      throw new Error(errorMessage)
+    }
+    this.option.url = url
+    this.option.method = method.toUpperCase()
+    return this
+  }
+
+  delete (url) { return this.wrapHttpMethod('delete', url) }
+  get (url) { return this.wrapHttpMethod('get', url) }
+  head (url) { return this.wrapHttpMethod('head', url) }
+  options (url) { return this.wrapHttpMethod('options', url) }
+  patch (url) { return this.wrapHttpMethod('patch', url) }
+  post (url) { return this.wrapHttpMethod('post', url) }
+  put (url) { return this.wrapHttpMethod('put', url) }
+  trace (url) { return this.wrapHttpMethod('trace', url) }
+
+  /**
+   * @private
+   * @param {string} method
+   * @param {string} url
+   */
+  wrapChainMethod (method, value) {
+    if (this._hasInvoked === true || this._promise) {
+      throw new Error(errorMessage)
+    }
+    this.option[method] = value
+    return this
+  }
+
+  body (url) { return this.wrapChainMethod('body', url) }
+  cookies (url) { return this.wrapChainMethod('cookies', url) }
+  headers (url) { return this.wrapChainMethod('headers', url) }
+  payload (url) { return this.wrapChainMethod('payload', url) }
+  query (url) { return this.wrapChainMethod('query', url) }
+
+  end (callback) {
+    if (this._hasInvoked === true || this._promise) {
+      throw new Error(errorMessage)
+    }
+    this._hasInvoked = true
+    if (typeof callback === 'function') {
+      doInject(this.dispatch, this.option, callback)
+    } else {
+      this._promise = doInject(this.dispatch, this.option)
+      return this._promise
+    }
+  }
+
+  /**
+   * @private
+   * @template {keyof Promise} T
+   * @param {T} method
+   * @param  {Parameters<Promise[T]>} args
+   */
+  promisify (method, args) {
+    if (!this._promise) {
+      if (this._hasInvoked === true) {
+        throw new Error(errorMessage)
+      }
+      this._hasInvoked = true
+      this._promise = doInject(this.dispatch, this.option)
+    }
+    return this._promise[method](...args)
+  }
+
+  then (...args) { return this.promisify('then', args) }
+  catch (...args) { return this.promisify('catch', args) }
+  finally (...args) { return this.promisify('finally', args) }
+}
+
+module.exports = Chain

--- a/lib/do-inject.js
+++ b/lib/do-inject.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const assert = require('assert')
+const optsValidator = require('./config-validator')
+const Request = require('./request')
+const { Response, once } = require('./response')
+const { Readable, addAbortSignal } = require('stream')
+
+function promisify (fn) {
+  if (fn) {
+    return { ret: Promise.resolve(), cb: once(fn) }
+  }
+  let resolve, reject
+  const ret = new Promise((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
+  })
+  return {
+    ret,
+    cb: (err, res) => {
+      err ? reject(err) : resolve(res)
+    }
+  }
+}
+
+function makeRequest (dispatchFunc, server, req, res) {
+  req.socket.once('close', function () {
+    res.emit('close')
+  })
+
+  return req.prepare(() => dispatchFunc.call(server, req, res), (err) => { res.emit('error', err) })
+}
+
+function doInject (dispatchFunc, options, callback) {
+  options = (typeof options === 'string' ? { url: options } : options)
+
+  if (options.validate !== false) {
+    assert(typeof dispatchFunc === 'function', 'dispatchFunc should be a function')
+    const isOptionValid = optsValidator(options)
+    if (!isOptionValid) {
+      throw new Error(optsValidator.errors.map(e => e.message))
+    }
+  }
+
+  const server = options.server || {}
+
+  const RequestConstructor = options.Request
+    ? Request.getCustomRequest(options.Request)
+    : Request
+
+  // Express.js detection
+  if (dispatchFunc.request && dispatchFunc.request.app === dispatchFunc) {
+    Object.setPrototypeOf(Object.getPrototypeOf(dispatchFunc.request), RequestConstructor.prototype)
+    Object.setPrototypeOf(Object.getPrototypeOf(dispatchFunc.response), Response.prototype)
+  }
+
+  const { ret, cb } = promisify(callback)
+
+  const req = new RequestConstructor(options)
+  const res = new Response(req, cb)
+
+  if (options.signal) {
+    const r = new Readable()
+    r.once('error', (err) => {
+      cb(err)
+      res.destroy(err)
+    })
+    res.once('close', () => {
+      r.destroy()
+    })
+    addAbortSignal(options.signal, r)
+  }
+
+  return Promise.resolve().then(() => makeRequest(dispatchFunc, server, req, res)).then(() => ret)
+}
+
+module.exports = doInject

--- a/lib/request.js
+++ b/lib/request.js
@@ -2,14 +2,14 @@
 
 /* eslint no-prototype-builtins: 0 */
 
-const { Readable, addAbortSignal } = require('stream')
-const util = require('util')
+const { Readable } = require('stream')
 const cookie = require('cookie')
 const assert = require('assert')
 const warning = require('process-warning')()
 
 const parseURL = require('./parse-url')
-const { EventEmitter } = require('events')
+const { IncomingMessage } = require('http')
+const { Socket } = require('net')
 
 // request.connectin deprecation https://nodejs.org/api/http.html#http_request_connection
 warning.create('FastifyDeprecationLightMyRequest', 'FST_LIGHTMYREQUEST_DEP01', 'You are accessing "request.connection", use "request.socket" instead.')
@@ -32,228 +32,214 @@ function hostHeaderFromURL (parsedURL) {
  * @constructor
  * @param {String} remoteAddress the fake address to show consumers of the socket
  */
-class MockSocket extends EventEmitter {
+class MockSocket extends Socket {
   constructor (remoteAddress) {
     super()
-    this.remoteAddress = remoteAddress
-  }
-}
-
-/**
- * CustomRequest
- *
- * @constructor
- * @param {Object} options
- * @param {(Object|String)} options.url || options.path
- * @param {String} [options.method='GET']
- * @param {String} [options.remoteAddress]
- * @param {Object} [options.cookies]
- * @param {Object} [options.headers]
- * @param {Object} [options.query]
- * @param {Object} [options.Request]
- * @param {any} [options.payload]
- */
-function CustomRequest (options) {
-  return new _CustomLMRRequest(this)
-
-  function _CustomLMRRequest (obj) {
-    Request.call(obj, {
-      ...options,
-      Request: undefined
+    Object.defineProperty(this, 'remoteAddress', {
+      __proto__: null,
+      configurable: false,
+      enumerable: true,
+      get: () => remoteAddress
     })
-    Object.assign(this, obj)
-
-    for (const fn of Object.keys(Request.prototype)) {
-      this.constructor.prototype[fn] = Request.prototype[fn]
-    }
-
-    util.inherits(this.constructor, options.Request)
-    return this
   }
 }
 
-/**
- * Request
- *
- * @constructor
- * @param {Object} options
- * @param {(Object|String)} options.url || options.path
- * @param {String} [options.method='GET']
- * @param {String} [options.remoteAddress]
- * @param {Object} [options.cookies]
- * @param {Object} [options.headers]
- * @param {Object} [options.query]
- * @param {any} [options.payload]
- */
-function Request (options) {
-  Readable.call(this, {
-    autoDestroy: false
-  })
+class Request extends IncomingMessage {
+  static errors = {
+    ContentLength: class ContentLengthError extends Error {
+      constructor () {
+        super('Content length is different than the value specified by the Content-Length header')
+      }
+    }
+  }
 
-  const parsedURL = parseURL(options.url || options.path, options.query)
+  /**
+   * Request
+   *
+   * @param {Object} options
+   * @param {(Object|String)} options.url || options.path
+   * @param {String} [options.method='GET']
+   * @param {String} [options.remoteAddress]
+   * @param {Object} [options.cookies]
+   * @param {Object} [options.headers]
+   * @param {Object} [options.query]
+   * @param {{end: boolean,split: boolean,error: boolean,close: boolean}} [options.simulate]
+   * @param {any} [options.payload]
+   */
+  constructor (options) {
+    super(new MockSocket(options.remoteAddress || '127.0.0.1'))
+    const parsedURL = parseURL(options.url || options.path, options.query)
 
-  this.url = parsedURL.pathname + parsedURL.search
+    this.url = parsedURL.pathname + parsedURL.search
 
-  this.aborted = false
-  this.httpVersionMajor = 1
-  this.httpVersionMinor = 1
-  this.httpVersion = '1.1'
-  this.method = options.method ? options.method.toUpperCase() : 'GET'
+    this.aborted = false
+    this.httpVersionMajor = 1
+    this.httpVersionMinor = 1
+    this.httpVersion = '1.1'
+    this.method = options.method ? options.method.toUpperCase() : 'GET'
 
-  this.headers = {}
-  this.rawHeaders = []
-  const headers = options.headers || {}
+    this.headers = {}
+    this.rawHeaders = []
+    const headers = options.headers || {}
 
-  for (const field in headers) {
-    const fieldLowerCase = field.toLowerCase()
-    if (
-      (
-        fieldLowerCase === 'user-agent' ||
+    for (const field in headers) {
+      const fieldLowerCase = field.toLowerCase()
+      if (
+        (
+          fieldLowerCase === 'user-agent' ||
         fieldLowerCase === 'content-type'
-      ) && headers[field] === undefined
-    ) {
-      this.headers[fieldLowerCase] = undefined
-      continue
-    }
-    const value = headers[field]
-    assert(value !== undefined, 'invalid value "undefined" for header ' + field)
-    this.headers[fieldLowerCase] = '' + value
-  }
-
-  if (('user-agent' in this.headers) === false) {
-    this.headers['user-agent'] = 'lightMyRequest'
-  }
-  this.headers.host = this.headers.host || options.authority || hostHeaderFromURL(parsedURL)
-
-  if (options.cookies) {
-    const { cookies } = options
-    const cookieValues = Object.keys(cookies).map(key => cookie.serialize(key, cookies[key]))
-    if (this.headers.cookie) {
-      cookieValues.unshift(this.headers.cookie)
-    }
-    this.headers.cookie = cookieValues.join('; ')
-  }
-
-  this.socket = new MockSocket(options.remoteAddress || '127.0.0.1')
-
-  Object.defineProperty(this, 'connection', {
-    get () {
-      warning.emit('FST_LIGHTMYREQUEST_DEP01')
-      return this.socket
-    },
-    configurable: true
-  })
-
-  // we keep both payload and body for compatibility reasons
-  let payload = options.payload || options.body || null
-  const payloadResume = payload && typeof payload.resume === 'function'
-
-  if (payload && typeof payload !== 'string' && !payloadResume && !Buffer.isBuffer(payload)) {
-    payload = JSON.stringify(payload)
-
-    if (('content-type' in this.headers) === false) {
-      this.headers['content-type'] = 'application/json'
-    }
-  }
-
-  // Set the content-length for the corresponding payload if none set
-  if (payload && !payloadResume && !Object.prototype.hasOwnProperty.call(this.headers, 'content-length')) {
-    this.headers['content-length'] = (Buffer.isBuffer(payload) ? payload.length : Buffer.byteLength(payload)).toString()
-  }
-
-  for (const header of Object.keys(this.headers)) {
-    this.rawHeaders.push(header, this.headers[header])
-  }
-
-  // Use _lightMyRequest namespace to avoid collision with Node
-  this._lightMyRequest = {
-    payload,
-    isDone: false,
-    simulate: options.simulate || {}
-  }
-
-  const signal = options.signal
-  /* istanbul ignore if  */
-  if (signal) {
-    addAbortSignal(signal, this)
-  }
-
-  return this
-}
-
-util.inherits(Request, Readable)
-util.inherits(CustomRequest, Request)
-
-Request.prototype.prepare = function (next) {
-  const payload = this._lightMyRequest.payload
-  if (!payload || typeof payload.resume !== 'function') { // does not quack like a stream
-    return next()
-  }
-
-  const chunks = []
-
-  payload.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
-
-  payload.on('end', () => {
-    const payload = Buffer.concat(chunks)
-    this.headers['content-length'] = this.headers['content-length'] || ('' + payload.length)
-    this._lightMyRequest.payload = payload
-    return next()
-  })
-
-  // Force to resume the stream. Needed for Stream 1
-  payload.resume()
-}
-
-Request.prototype._read = function (size) {
-  setImmediate(() => {
-    if (this._lightMyRequest.isDone) {
-      // 'end' defaults to true
-      if (this._lightMyRequest.simulate.end !== false) {
-        this.push(null)
+        ) && headers[field] === undefined
+      ) {
+        this.headers[fieldLowerCase] = undefined
+        continue
       }
-
-      return
+      const value = headers[field]
+      assert(value !== undefined, 'invalid value "undefined" for header ' + field)
+      this.headers[fieldLowerCase] = '' + value
     }
 
-    this._lightMyRequest.isDone = true
+    if (('user-agent' in this.headers) === false) {
+      this.headers['user-agent'] = 'lightMyRequest'
+    }
+    this.headers.host = this.headers.host || options.authority || hostHeaderFromURL(parsedURL)
 
-    if (this._lightMyRequest.payload) {
-      if (this._lightMyRequest.simulate.split) {
-        this.push(this._lightMyRequest.payload.slice(0, 1))
-        this.push(this._lightMyRequest.payload.slice(1))
+    if (options.cookies) {
+      const { cookies } = options
+      const cookieValues = Object.keys(cookies).map(key => cookie.serialize(key, cookies[key]))
+      if (this.headers.cookie) {
+        cookieValues.unshift(this.headers.cookie)
+      }
+      this.headers.cookie = cookieValues.join('; ')
+    }
+
+    Object.defineProperty(this, 'connection', {
+      get () {
+        warning.emit('FST_LIGHTMYREQUEST_DEP01')
+        return this.socket
+      },
+      configurable: true
+    })
+
+    // we keep both payload and body for compatibility reasons
+    let payload = options.payload || options.body || null
+    const payloadResume = payload && typeof payload.resume === 'function'
+
+    if (payload && typeof payload !== 'string' && !payloadResume && !Buffer.isBuffer(payload)) {
+      payload = JSON.stringify(payload)
+
+      if (('content-type' in this.headers) === false) {
+        this.headers['content-type'] = 'application/json'
+      }
+    }
+
+    for (const header of Object.keys(this.headers)) {
+      this.rawHeaders.push(header, this.headers[header])
+    }
+
+    if (options.simulate?.end === false) {
+      const prevPayload = payload
+      if (payloadResume) {
+        payload = new Readable({
+          read (n) {
+            prevPayload.read(n)
+          }
+        })
+        prevPayload.on('data', (d) => {
+          payload.push(d)
+        })
       } else {
-        this.push(this._lightMyRequest.payload)
+        payload = new Readable({
+          read (n) {
+            if (prevPayload) this.push(prevPayload)
+            this.pause()
+          }
+        })
       }
     }
 
-    if (this._lightMyRequest.simulate.error) {
-      this.emit('error', new Error('Simulated'))
+    // Use _lightMyRequest namespace to avoid collision with Node
+    this._lightMyRequest = {
+      payload,
+      isDone: false,
+      simulate: options.simulate || {}
+    }
+  }
+
+  getLength (payload) {
+    if (typeof payload === 'string') {
+      return Buffer.byteLength(payload)
     }
 
-    if (this._lightMyRequest.simulate.close) {
-      this.emit('close')
-    }
+    return payload.length
+  }
 
-    // 'end' defaults to true
-    if (this._lightMyRequest.simulate.end !== false) {
+  prepare (next, onError) {
+    let payload = this._lightMyRequest.payload
+    this.complete = true
+    if (payload) {
+      if (typeof payload.resume !== 'function') {
+        const length = this.getLength(payload)
+        if (this.headers['content-length']) {
+          if (this.headers['content-length'].toString() > length.toString()) {
+            return onError(new Request.errors.ContentLength())
+          }
+          payload = payload.slice(0, this.headers['content-length'])
+        } else {
+          this.headers['content-length'] = length?.toString()
+        }
+        this.push(payload)
+        this.push(null)
+      } else {
+        let i = 0
+        const max = this.headers['content-length'] ? parseInt(this.headers['content-length'], 10) : null
+        payload.on('data', (chunk) => {
+          if (max != null) {
+            if (max > i && max <= i + chunk.length) {
+              this.push(chunk.slice(0, max - i))
+            }
+          } else {
+            this.push(chunk)
+          }
+          i += chunk.length
+        })
+        payload.on('end', () => {
+          if (max != null) {
+            if (max > i) {
+              return onError(new Request.errors.ContentLength())
+            }
+          }
+          this.push(null)
+        })
+        payload.resume()
+      }
+    } else {
+      if (this.headers['content-length'] && this.headers['content-length'] !== '0') {
+        return onError(new Request.errors.ContentLength())
+      }
       this.push(null)
     }
-  })
+    return next()
+  }
 }
 
-Request.prototype.destroy = function (error) {
-  if (this.destroyed || this._lightMyRequest.isDone) return
-  this.destroyed = true
-
-  if (error) {
-    this._error = true
-    process.nextTick(() => this.emit('error', error))
+/**
+ * @template T
+ * @param {new (opt: import('../types').InjectOptions) => T} CustomRequest
+ * @returns {new (opt: import('../types').InjectOptions) => T & Request}
+ */
+function getCustomRequest (CustomRequest) {
+  class _CustomLMRRequest extends CustomRequest {
+    constructor (...opt) {
+      super(...opt)
+      Object.assign(this, new Request(...opt))
+    }
   }
-
-  process.nextTick(() => this.emit('close'))
+  Object.getOwnPropertyNames(Request.prototype)
+    .filter(prop => prop !== 'constructor')
+    .forEach(prop => { _CustomLMRRequest.prototype[prop] = Request.prototype[prop] })
+  return _CustomLMRRequest
 }
 
 module.exports = Request
 module.exports.Request = Request
-module.exports.CustomRequest = CustomRequest
+module.exports.getCustomRequest = getCustomRequest

--- a/lib/request.js
+++ b/lib/request.js
@@ -78,6 +78,16 @@ class Request extends IncomingMessage {
     this.httpVersion = '1.1'
     this.method = options.method ? options.method.toUpperCase() : 'GET'
 
+    // Use _lightMyRequest namespace to avoid collision with Node
+    this._lightMyRequest = {
+      payload: options.payload || options.body || null,
+      isDone: false,
+      simulate: options.simulate || {},
+      authority: options.authority,
+      cookies: options.cookies,
+      hostHeader: hostHeaderFromURL(parsedURL)
+    }
+
     this.headers = {}
     this.rawHeaders = []
     const headers = options.headers || {}
@@ -98,20 +108,6 @@ class Request extends IncomingMessage {
       this.headers[fieldLowerCase] = '' + value
     }
 
-    if (('user-agent' in this.headers) === false) {
-      this.headers['user-agent'] = 'lightMyRequest'
-    }
-    this.headers.host = this.headers.host || options.authority || hostHeaderFromURL(parsedURL)
-
-    if (options.cookies) {
-      const { cookies } = options
-      const cookieValues = Object.keys(cookies).map(key => cookie.serialize(key, cookies[key]))
-      if (this.headers.cookie) {
-        cookieValues.unshift(this.headers.cookie)
-      }
-      this.headers.cookie = cookieValues.join('; ')
-    }
-
     Object.defineProperty(this, 'connection', {
       get () {
         warning.emit('FST_LIGHTMYREQUEST_DEP01')
@@ -119,9 +115,35 @@ class Request extends IncomingMessage {
       },
       configurable: true
     })
+  }
 
+  getLength (payload) {
+    if (typeof payload === 'string') {
+      return Buffer.byteLength(payload)
+    }
+
+    return payload.length
+  }
+
+  parseHeader () {
+    if (('user-agent' in this.headers) === false) {
+      this.headers['user-agent'] = 'lightMyRequest'
+    }
+    this.headers.host = this.headers.host || this._lightMyRequest.authority || this._lightMyRequest.hostHeader
+
+    if (this._lightMyRequest.cookies) {
+      const { cookies } = this._lightMyRequest
+      const cookieValues = Object.keys(cookies).map(key => cookie.serialize(key, cookies[key]))
+      if (this.headers.cookie) {
+        cookieValues.unshift(this.headers.cookie)
+      }
+      this.headers.cookie = cookieValues.join('; ')
+    }
+  }
+
+  parsePayload () {
     // we keep both payload and body for compatibility reasons
-    let payload = options.payload || options.body || null
+    let payload = this._lightMyRequest.payload
     const payloadResume = payload && typeof payload.resume === 'function'
 
     if (payload && typeof payload !== 'string' && !payloadResume && !Buffer.isBuffer(payload)) {
@@ -132,11 +154,7 @@ class Request extends IncomingMessage {
       }
     }
 
-    for (const header of Object.keys(this.headers)) {
-      this.rawHeaders.push(header, this.headers[header])
-    }
-
-    if (options.simulate?.end === false) {
+    if (this._lightMyRequest.simulate.end === false) {
       const prevPayload = payload
       if (payloadResume) {
         payload = new Readable({
@@ -157,23 +175,15 @@ class Request extends IncomingMessage {
       }
     }
 
-    // Use _lightMyRequest namespace to avoid collision with Node
-    this._lightMyRequest = {
-      payload,
-      isDone: false,
-      simulate: options.simulate || {}
-    }
-  }
-
-  getLength (payload) {
-    if (typeof payload === 'string') {
-      return Buffer.byteLength(payload)
-    }
-
-    return payload.length
+    this._lightMyRequest.payload = payload
   }
 
   prepare (next, onError) {
+    this.parseHeader()
+    this.parsePayload()
+    for (const header of Object.keys(this.headers)) {
+      this.rawHeaders.push(header, this.headers[header])
+    }
     let payload = this._lightMyRequest.payload
     this.complete = true
     if (payload) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,184 +1,120 @@
 'use strict'
 
 const http = require('http')
-const { Writable } = require('stream')
-const util = require('util')
 
 const setCookie = require('set-cookie-parser')
+const MySocket = require('./socket')
 
-function Response (req, onEnd, reject) {
-  http.ServerResponse.call(this, req)
-
-  this._lightMyRequest = { headers: null, trailers: {}, payloadChunks: [] }
-  // This forces node@8 to always render the headers
-  this.setHeader('foo', 'bar'); this.removeHeader('foo')
-
-  this.assignSocket(getNullSocket())
-
-  this._promiseCallback = typeof reject === 'function'
-
+function once (cb) {
   let called = false
-  const onEndSuccess = (payload) => {
-    // no need to early-return if already called because this handler is bound `once`
-    called = true
-    if (this._promiseCallback) {
-      return process.nextTick(() => onEnd(payload))
-    }
-    process.nextTick(() => onEnd(null, payload))
-  }
-
-  const onEndFailure = (err) => {
+  return function () {
     if (called) return
     called = true
-    if (this._promiseCallback) {
-      return process.nextTick(() => reject(err))
-    }
-    process.nextTick(() => onEnd(err, null))
-  }
-
-  this.once('finish', () => {
-    const res = generatePayload(this)
-    res.raw.req = req
-    onEndSuccess(res)
-  })
-
-  this.connection.once('error', onEndFailure)
-
-  this.once('error', onEndFailure)
-
-  this.once('close', onEndFailure)
-}
-
-util.inherits(Response, http.ServerResponse)
-
-Response.prototype.setTimeout = function (msecs, callback) {
-  this.timeoutHandle = setTimeout(() => {
-    this.emit('timeout')
-  }, msecs)
-  this.on('timeout', callback)
-  return this
-}
-
-Response.prototype.writeHead = function () {
-  const result = http.ServerResponse.prototype.writeHead.apply(this, arguments)
-
-  copyHeaders(this)
-
-  return result
-}
-
-Response.prototype.write = function (data, encoding, callback) {
-  if (this.timeoutHandle) {
-    clearTimeout(this.timeoutHandle)
-  }
-  http.ServerResponse.prototype.write.call(this, data, encoding, callback)
-  this._lightMyRequest.payloadChunks.push(Buffer.from(data, encoding))
-  return true
-}
-
-Response.prototype.end = function (data, encoding, callback) {
-  if (data) {
-    this.write(data, encoding)
-  }
-
-  http.ServerResponse.prototype.end.call(this, callback)
-
-  this.emit('finish')
-
-  // We need to emit 'close' otherwise stream.finished() would
-  // not pick it up on Node v16
-
-  this.destroy()
-}
-
-Response.prototype.destroy = function (error) {
-  if (this.destroyed) return
-  this.destroyed = true
-
-  if (error) {
-    process.nextTick(() => this.emit('error', error))
-  }
-
-  process.nextTick(() => this.emit('close'))
-}
-
-Response.prototype.addTrailers = function (trailers) {
-  for (const key in trailers) {
-    this._lightMyRequest.trailers[key.toLowerCase().trim()] = trailers[key].toString().trim()
+    cb.apply(this, arguments)
   }
 }
 
-function generatePayload (response) {
-  // This seems only to happen when using `fastify-express` - see https://github.com/fastify/fastify-express/issues/47
-  /* istanbul ignore if */
-  if (response._lightMyRequest.headers === null) {
-    copyHeaders(response)
-  }
-  serializeHeaders(response)
-  // Prepare response object
-  const res = {
-    raw: {
-      res: response
-    },
-    headers: response._lightMyRequest.headers,
-    statusCode: response.statusCode,
-    statusMessage: response.statusMessage,
-    trailers: {},
-    get cookies () {
-      return setCookie.parse(this)
-    }
-  }
-
-  // Prepare payload and trailers
-  const rawBuffer = Buffer.concat(response._lightMyRequest.payloadChunks)
-  res.rawPayload = rawBuffer
-
-  // we keep both of them for compatibility reasons
-  res.payload = rawBuffer.toString()
-  res.body = res.payload
-  res.trailers = response._lightMyRequest.trailers
-
-  // Prepare payload parsers
-  res.json = function parseJsonPayload () {
-    return JSON.parse(res.payload)
-  }
-
-  return res
-}
+module.exports.once = once
 
 // Throws away all written data to prevent response from buffering payload
-function getNullSocket () {
-  return new Writable({
-    write (chunk, encoding, callback) {
-      setImmediate(callback)
-    }
-  })
-}
 
-function serializeHeaders (response) {
-  const headers = response._lightMyRequest.headers
-
-  for (const headerName of Object.keys(headers)) {
-    const headerValue = headers[headerName]
-    if (Array.isArray(headerValue)) {
-      headers[headerName] = headerValue.map(value => '' + value)
-    } else {
-      headers[headerName] = '' + headerValue
+class Response extends http.ServerResponse {
+  static errors = {
+    SocketHangUpError: class SocketHangUpError extends Error {
+      constructor () {
+        super('socket hang up')
+        this.code = 'ECONNRESET'
+      }
     }
+  }
+
+  /**
+   * @param {import('./request').Request} req
+   * @param {(err: Error, data: any) => void} onEnd
+   * @param {http.Server} server
+   */
+  constructor (req, onEnd) {
+    super(req)
+    onEnd = once(onEnd)
+    this._lightSocket = new MySocket()
+    this.setHeader('foo', 'bar'); this.removeHeader('foo')
+    this.assignSocket(this._lightSocket)
+
+    const onEndCb = (err) => {
+      if (err) {
+        return process.nextTick(() => onEnd(err))
+      }
+      const res = this.generatePayload(req)
+      if (res.end) {
+        return process.nextTick(() => onEnd(null, res))
+      }
+      process.nextTick(() => onEnd(new Response.errors.SocketHangUpError()))
+    }
+
+    this.once('finish', () => {
+      this.destroyed = true
+      this._closed = true
+      this.emit('close')
+    })
+
+    this.once('close', () => {
+      onEndCb()
+    })
+
+    this.socket.once('error', () => {
+      onEndCb(new Response.errors.SocketHangUpError())
+    })
+
+    this.socket.once('close', () => {
+      process.nextTick(() => onEndCb())
+    })
+
+    this.once('error', (err) => {
+      onEndCb(err)
+    })
+  }
+
+  setTimeout (msecs, callback) {
+    this.timeoutHandle = setTimeout(() => {
+      this.emit('timeout')
+    }, msecs)
+    this.on('timeout', callback)
+    return this
+  }
+
+  /**
+   * @private
+   * @param {Request} req
+   * @returns
+   */
+  generatePayload (req) {
+    // This seems only to happen when using `fastify-express` - see https://github.com/fastify/fastify-express/issues/47
+    // Prepare response object
+    const state = this._lightSocket.getState()
+    const body = state.body.toString()
+    const res = {
+      raw: {
+        res: this,
+        req
+      },
+      headers: state.headers,
+      statusCode: this.statusCode,
+      statusMessage: this.statusMessage,
+      trailers: state.trailers,
+      rawPayload: state.body,
+      end: state.isEnd,
+      payload: body,
+      body,
+      json: function parseJsonPayload () {
+        return JSON.parse(res.payload)
+      },
+      get cookies () {
+        return setCookie.parse(this)
+      }
+    }
+
+    return res
   }
 }
 
-function copyHeaders (response) {
-  response._lightMyRequest.headers = Object.assign({}, response.getHeaders())
-
-  // Add raw headers
-  ;['Date', 'Connection', 'Transfer-Encoding'].forEach((name) => {
-    const regex = new RegExp('\\r\\n' + name + ': ([^\\r]*)\\r\\n')
-    const field = response._header.match(regex)
-    if (field) {
-      response._lightMyRequest.headers[name.toLowerCase()] = field[1]
-    }
-  })
-}
-
-module.exports = Response
+module.exports.Response = Response

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -1,0 +1,138 @@
+const { Socket } = require('net')
+
+const crlfBuf = Buffer.from('\r\n')
+
+class State {
+  constructor () {
+    this.state = 'firstHead'
+    this.headers = {}
+    this.trailers = {}
+    this.body = []
+    this.waitSizeBody = 0
+    this.rawBody = []
+  }
+
+  /**
+   * @param {Uint8Array | string} chunk
+   * @param {BufferEncoding} [encoding]
+   */
+  write (chunk, encoding) {
+    if (typeof chunk === 'string') {
+      chunk = Buffer.from(chunk, encoding)
+    }
+    this.rawBody.push(chunk)
+    this.process(Buffer.concat(this.rawBody))
+  }
+
+  /**
+   * @private
+   * @param {Buffer} buffer
+   * @returns
+   */
+  process (buffer) {
+    if (!buffer.length) {
+      this.rawBody = []
+      return
+    };
+    if (this.state === 'body') {
+      if (buffer.length < this.waitSizeBody) {
+        this.body.push(buffer)
+        this.waitSizeBody -= buffer.length
+        this.rawBody = []
+        return
+      }
+      this.body.push(buffer.subarray(0, this.waitSizeBody))
+      const size = this.waitSizeBody
+      this.waitSizeBody = 0
+      this.state = 'afterBody'
+      this.process(buffer.subarray(size))
+      return
+    }
+    this.rawBody = [buffer]
+    const i = buffer.indexOf(crlfBuf)
+    if (i === -1) {
+      return
+    };
+    if (this.state === 'firstHead') {
+      this.state = 'head'
+      this.process(buffer.subarray(i + 2))
+      return
+    }
+    if (this.state === 'head') {
+      const line = buffer.subarray(0, i).toString()
+      if (line) {
+        const [, key, value] = line.match(/^([^:]+): (.*)$/)
+        if (this.headers[key.toLowerCase()]) {
+          if (!Array.isArray(this.headers[key.toLowerCase()])) {
+            this.headers[key.toLowerCase()] = [this.headers[key.toLowerCase()]]
+          }
+          this.headers[key.toLowerCase()].push(value)
+        } else {
+          this.headers[key.toLowerCase()] = value
+        }
+      } else if (this.headers['content-length']) {
+        this.waitSizeBody = parseInt(this.headers['content-length'])
+        if (this.waitSizeBody) {
+          this.state = 'body'
+        } else {
+          this.state = 'trailers'
+        }
+      } else {
+        this.state = 'bodySize'
+      }
+      this.process(buffer.subarray(i + 2))
+      return
+    }
+    if (this.state === 'bodySize') {
+      const chunk = buffer.subarray(0, i).toString()
+      this.waitSizeBody = parseInt(chunk.toString(), 16)
+      if (this.waitSizeBody !== 0) {
+        this.state = 'body'
+      } else {
+        this.state = 'trailers'
+      }
+      this.process(buffer.subarray(i + 2))
+      return
+    }
+    if (this.state === 'afterBody') {
+      this.state = 'bodySize'
+      this.process(buffer.subarray(i + 2))
+    }
+    if (this.state === 'trailers') {
+      const line = buffer.subarray(0, i).toString()
+      if (line) {
+        const [, key, value] = line.match(/^([^:]+): (.*)$/)
+        this.trailers[key.toLowerCase()] = value
+      } else {
+        this.state = 'end'
+      }
+      this.process(buffer.subarray(i + 2))
+    }
+  }
+}
+
+class MySocket extends Socket {
+  _myData = new State()
+
+  /**
+   * @param {Uint8Array | string} chunk
+   * @param {BufferEncoding | (err?: Error) => void} [encoding]
+   * @param {(err?: Error) => void} [callback]
+   */
+  write (chunk, encoding, callback) {
+    this._myData.write(chunk, encoding)
+    callback && setImmediate(callback)
+    return true
+  }
+
+  getState () {
+    return {
+      headers: this._myData.headers,
+      body: Buffer.concat(this._myData.body),
+      trailers: this._myData.trailers,
+      isEnd: ['end', 'trailers', 'afterBody', 'bodySize'].includes(this._myData.state)
+    }
+  }
+}
+
+module.exports = MySocket

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -1,13 +1,13 @@
 const { test } = require('tap')
 
-const Response = require('../lib/response')
+const { Response } = require('../lib/response')
 
 test('multiple calls to res.destroy should not be called', (t) => {
   t.plan(1)
 
   const mockReq = {}
   const res = new Response(mockReq, (err, response) => {
-    t.error(err)
+    t.equal(err instanceof Response.errors.SocketHangUpError, true)
   })
 
   res.destroy()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,7 +14,7 @@ declare namespace inject {
 
   export type DispatchFunc = http.RequestListener
 
-  export type CallbackFunc = (err: Error, response: Response) => void
+  export type CallbackFunc = (err: Error | undefined, response: Response | undefined) => void
 
   export type InjectPayload = string | object | Buffer | NodeJS.ReadableStream
 
@@ -22,6 +22,11 @@ declare namespace inject {
 
   export interface AbortSignal {
     readonly aborted: boolean;
+  }
+
+  export const errors: {
+    ContentLength: typeof Error,
+    SocketHangUpError: typeof Error,
   }
 
   export interface InjectOptions {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,5 +1,5 @@
 import * as http from 'http'
-import { inject, isInjection, Response, DispatchFunc, InjectOptions, Chain } from '..'
+import { inject, isInjection, Response, DispatchFunc, InjectOptions, Chain, errors } from '..'
 import { expectType, expectAssignable, expectNotAssignable } from 'tsd'
 
 expectAssignable<InjectOptions>({ url: '/' })
@@ -15,7 +15,13 @@ const dispatch: http.RequestListener = function (req, res) {
   res.end(reply)
 }
 
-const expectResponse = function (res: Response) {
+expectType<typeof Error>(errors.ContentLength)
+expectType<typeof Error>(errors.SocketHangUpError)
+
+const expectResponse = function (res: Response | undefined) {
+  if (!res) {
+    return;
+  }
   expectType<Response>(res)
   console.log(res.payload)
   expectAssignable<Function>(res.json)
@@ -38,7 +44,7 @@ const expectResponse = function (res: Response) {
 expectType<DispatchFunc>(dispatch)
 
 inject(dispatch, { method: 'get', url: '/' }, (err, res) => {
-  expectType<Error>(err)
+  expectType<Error | undefined>(err)
   expectResponse(res)
 })
 
@@ -52,37 +58,37 @@ const url = {
   }
 }
 inject(dispatch, { method: 'get', url }, (err, res) => {
-  expectType<Error>(err)
+  expectType<Error | undefined>(err)
   expectResponse(res)
 })
 
 inject(dispatch, { method: 'get', url: '/', cookies: { name1: 'value1', value2: 'value2' } }, (err, res) => {
-  expectType<Error>(err)
+  expectType<Error | undefined>(err)
   expectResponse(res)
 })
 
 inject(dispatch, { method: 'get', url: '/', query: { name1: 'value1', value2: 'value2' } }, (err, res) => {
-  expectType<Error>(err)
+  expectType<Error | undefined>(err)
   expectResponse(res)
 })
 
 inject(dispatch, { method: 'get', url: '/', query: { name1: ['value1', 'value2'] } }, (err, res) => {
-  expectType<Error>(err)
+  expectType<Error | undefined>(err)
   expectResponse(res)
 })
 
 inject(dispatch, { method: 'get', url: '/', query: 'name1=value1' }, (err, res) => {
-  expectType<Error>(err)
+  expectType<Error | undefined>(err)
   expectResponse(res)
 })
 
 inject(dispatch, { method: 'post', url: '/', payload: { name1: 'value1', value2: 'value2' } }, (err, res) => {
-  expectType<Error>(err)
+  expectType<Error | undefined>(err)
   expectResponse(res)
 })
 
 inject(dispatch, { method: 'post', url: '/', body: { name1: 'value1', value2: 'value2' } }, (err, res) => {
-  expectType<Error>(err)
+  expectType<Error | undefined>(err)
   expectResponse(res)
 })
 
@@ -90,9 +96,9 @@ expectType<void>(
   inject(dispatch)
     .get('/')
     .end((err, res) => {
-      expectType<Error>(err)
-      expectType<Response>(res)
-      console.log(res.payload)
+      expectType<Error | undefined>(err)
+      expectType<Response | undefined>(res)
+      console.log(res?.payload)
     })
 )
 
@@ -129,6 +135,6 @@ const httpDispatch = function (req: http.IncomingMessage, res: http.ServerRespon
 }
 
 inject(httpDispatch, { method: 'get', url: '/' }, (err, res) => {
-  expectType<Error>(err)
+  expectType<Error | undefined>(err)
   expectResponse(res)
 })


### PR DESCRIPTION
migrate to class syntax (Chain, request, response)
add a mock socket class (parse headers, body, trailers)
change emitting and subscription

this is the sequel to https://github.com/fastify/light-my-request/pull/252

bun.js support
update usage of deprecated attribute
- [http.ServerResponse._header](https://github.com/fastify/light-my-request/blob/v5.10.0/lib/response.js#L177)
- [http.ServerResponse.connection](https://github.com/fastify/light-my-request/blob/v5.10.0/lib/response.js#L45)

some test was changed due to unexpected behavior
the main tests were tested with
```js
http.createServer(inj).listen(3000, () => {
  const r = http.request({ port: 3000, method: 'POST' }, (res) => cb(null, res)).on('error', cb)
  payload && payload.pipe(r)
  r.end()
});
``` 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added (.d.ts)
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
