### PR TITLE
Make the benchmark more useful

### DIFF
--- a/benchmark/suite.js
+++ b/benchmark/suite.js
@@ -1,0 +1,118 @@
+class Benchmark {
+  opsPerSec = 0
+  mean = 0
+  deviation = 0
+
+  constructor (name, fn) {
+    this.name = name
+    this.fn = fn
+    this.maxSample = 100
+  }
+
+  async runAsync (limitTime) {
+    let time = 0
+    let times = 0
+    const samples = []
+    while (time < limitTime * 1e6) {
+      const timeStart = process.hrtime()
+      await this.fn()
+      const timeEnd = process.hrtime(timeStart)
+      time += timeEnd[0] * 1e9 + timeEnd[1]
+      samples.push(timeEnd[0] * 1e9 + timeEnd[1])
+      times++
+    }
+    this.time = time
+    this.times = times
+    return samples
+  }
+
+  runSync (limitTime) {
+    let time = 0
+    let times = 0
+    const samples = []
+    while (time < limitTime * 1e6) {
+      const timeStart = process.hrtime()
+      this.fn()
+      const timeEnd = process.hrtime(timeStart)
+      time += timeEnd[0] * 1e9 + timeEnd[1]
+      samples.push(timeEnd[0] * 1e9 + timeEnd[1])
+      times++
+    }
+    this.time = time
+    this.times = times
+    return samples
+  }
+
+  batch (samples) {
+    if (samples.length > this.maxSample) {
+      const newSamples = []
+      const batchLength = Math.floor(samples.length / this.maxSample)
+      for (let i = 0; i < samples.length; i += batchLength) {
+        const batch = samples.slice(i, i + batchLength)
+        if (batchLength !== batch.length) continue
+        newSamples.push(batch.reduce((a, b) => a + b, 0))
+      }
+      return { samples: newSamples, batchLength }
+    }
+    return { samples, batchLength: 1 }
+  }
+
+  async run (limitTime) {
+    const isPromise = this.fn() instanceof Promise
+
+    const { samples: bSamples, batchLength } = this.batch(isPromise ? await this.runAsync(limitTime) : this.runSync(limitTime))
+
+    const sum = bSamples.reduce((a, b) => a + b, 0)
+    this.mean = bSamples.reduce((a, b) => a + b, 0) / bSamples.length
+    this.deviation = Math.sqrt(bSamples.reduce((a, b) => a + (b - this.mean) ** 2, 0) / bSamples.length)
+    this.opsPerSec = (bSamples.length * batchLength / (sum / 1e9)).toFixed()
+  }
+
+  toString () {
+    return `${this.name} x ${this.opsPerSec} ops/sec ±${(this.deviation / this.mean * 100).toFixed(2)}% (${this.times} runs sampled)`
+  }
+}
+
+class Suite {
+  /** @type {Benchmark[]} */
+  benchmarks = []
+  callbacks = {}
+
+  constructor (opt) {
+    this.opt = Object.assign({
+      msPerBenchmark: 1000
+    }, opt || {})
+  }
+
+  add (name, fn) {
+    this.benchmarks.push(new Benchmark(name, fn))
+    return this
+  }
+
+  async run () {
+    for await (const benchmark of this.benchmarks) {
+      try {
+        await benchmark.run(this.opt.msPerBenchmark)
+      } catch (err) {
+        console.error(benchmark.name, err)
+      }
+      this.callbacks.cycle?.forEach((listener) => listener({
+        name: benchmark.name,
+        target: benchmark
+      }))
+    }
+  }
+
+  on (event, cb) {
+    if (!this.callbacks[event]) this.callbacks[event] = []
+    this.callbacks[event].push(cb)
+    return this
+  }
+
+  onCycle (cb) {
+    if (!this.callbacks.cycle) this.callbacks.cycle = []
+    this.callbacks.cycle.push(cb)
+  }
+}
+
+module.exports = Suite


### PR DESCRIPTION
Add async benchmarks
use process.hrtime()

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
