### PR TITLE
Improve benchmarks

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -154,6 +154,11 @@ suite
     assert(d.payload === '1')
   })
   .run()
-  .then(() => {
-    console.table(suite.table())
+  .then((tasks) => {
+    const errors = tasks.map(t => t.result?.error).filter((t) => t)
+    if (errors.length) {
+      errors.map((e) => console.error(e))
+    } else {
+      console.table(suite.table())
+    }
   })

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -103,8 +103,8 @@ suite
       xs: ['foo', 'bar']
     })
   })
-  .add('read request body JSON', async function () {
-    await new Promise((resolve) => {
+  .add('read request body JSON', function () {
+    return new Promise((resolve) => {
       const req = new Request(mockReqCookiesPayload)
       req.prepare(() => {
         req.on('data', () => {})
@@ -112,8 +112,8 @@ suite
       })
     })
   })
-  .add('read request body buffer', async function () {
-    await new Promise((resolve) => {
+  .add('read request body buffer', function () {
+    return new Promise((resolve) => {
       const req = new Request(mockReqCookiesPayloadBuffer)
       req.prepare(() => {
         req.on('data', () => {})
@@ -121,8 +121,8 @@ suite
       })
     })
   })
-  .add('read request body readable', async function () {
-    await new Promise((resolve) => {
+  .add('read request body readable', function () {
+    return new Promise((resolve) => {
       const req = new Request(mockReqCookiesPayloadReadable())
       req.prepare(() => {
         req.on('data', () => {})
@@ -130,15 +130,15 @@ suite
       })
     })
   })
-  .add('Response write end', async function () {
+  .add('Response write end', function () {
     const req = new Request(mockReq)
-    await new Promise((resolve) => {
+    return new Promise((resolve) => {
       const res = new Response(req, resolve)
       res.write('foo')
       res.end()
     })
   })
-  .add('Response writeHead end', async function () {
+  .add('Response writeHead end', function () {
     const req = new Request(mockReq)
     return new Promise((resolve) => {
       const res = new Response(req, resolve)

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -1,11 +1,15 @@
 'use strict'
 
 const http = require('http')
-
-const Benchmark = require('benchmark')
-const suite = new Benchmark.Suite()
 const Request = require('../lib/request')
-const parseURL = require('../lib/parseURL')
+const Response = require('../lib/response')
+const inject = require('..')
+const parseURL = require('../lib/parse-url')
+const { Readable } = require('stream')
+const { assert } = require('console')
+const { Bench } = require('tinybench')
+
+const suite = new Bench()
 
 const mockReq = {
   url: 'http://localhost',
@@ -53,6 +57,28 @@ const mockReqCookiesPayload = {
     bim: { bar: { boom: 'paf' } }
   }
 }
+const mockReqCookiesPayloadBuffer = {
+  url: 'http://localhost',
+  method: 'GET',
+  headers: {
+    foo: 'bar',
+    'content-type': 'html',
+    accepts: 'json',
+    authorization: 'granted'
+  },
+  payload: Buffer.from('foo')
+}
+const mockReqCookiesPayloadReadable = () => ({
+  url: 'http://localhost',
+  method: 'GET',
+  headers: {
+    foo: 'bar',
+    'content-type': 'html',
+    accepts: 'json',
+    authorization: 'granted'
+  },
+  payload: Readable.from(['foo', 'bar', 'baz'])
+})
 
 suite
   .add('Request', function () {
@@ -77,7 +103,57 @@ suite
       xs: ['foo', 'bar']
     })
   })
-  .on('cycle', function (event) {
-    console.log(String(event.target))
+  .add('read request body JSON', async function () {
+    await new Promise((resolve) => {
+      const req = new Request(mockReqCookiesPayload)
+      req.prepare(() => {
+        req.on('data', () => {})
+        req.on('end', resolve)
+      })
+    })
+  })
+  .add('read request body buffer', async function () {
+    await new Promise((resolve) => {
+      const req = new Request(mockReqCookiesPayloadBuffer)
+      req.prepare(() => {
+        req.on('data', () => {})
+        req.on('end', resolve)
+      })
+    })
+  })
+  .add('read request body readable', async function () {
+    await new Promise((resolve) => {
+      const req = new Request(mockReqCookiesPayloadReadable())
+      req.prepare(() => {
+        req.on('data', () => {})
+        req.on('end', resolve)
+      })
+    })
+  })
+  .add('Response write end', async function () {
+    const req = new Request(mockReq)
+    await new Promise((resolve) => {
+      const res = new Response(req, () => resolve())
+      res.write('foo')
+      res.end()
+    })
+  })
+  .add('Response writeHead end', async function () {
+    const req = new Request(mockReq)
+    await new Promise((resolve) => {
+      const res = new Response(req, () => resolve())
+      res.writeHead(400, { 'content-length': 200 })
+      res.end()
+    })
+  })
+  .add('base inject', async function () {
+    const d = await inject((req, res) => {
+      req.on('data', () => {})
+      req.on('end', () => { res.end('1') })
+    }, mockReqCookiesPayload)
+    assert(d.payload === '1')
   })
   .run()
+  .then(() => {
+    console.table(suite.table())
+  })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fastify/ajv-compiler": "^3.1.0",
     "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^20.1.0",
-    "benchmark": "^2.1.4",
+    "tinybench": "^2.5.0",
     "end-of-stream": "^1.4.4",
     "express": "^4.17.1",
     "form-auto-content": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fastify/ajv-compiler": "^3.1.0",
     "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^20.1.0",
-    "tinybench": "^2.5.0",
+    "tinybench": "^2.5.1",
     "end-of-stream": "^1.4.4",
     "express": "^4.17.1",
     "form-auto-content": "^3.0.0",


### PR DESCRIPTION
Add async benchmarks
use process.hrtime()

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
