### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Does not use a socket connection so can be run against an inactive server (serve
 ## Example
 
 ```javascript
-const http = require('http')
+const http = require('node:http')
 const inject = require('light-my-request')
 
 const dispatch = function (req, res) {
@@ -77,7 +77,7 @@ File uploads (`multipart/form-data`) or form submit (`x-www-form-urlencoded`) ca
 
 ```js
 const formAutoContent = require('form-auto-content')
-const fs = require('fs')
+const fs = require('node:fs')
 
 try {
   const form = formAutoContent({

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 
 const Benchmark = require('benchmark')
 const suite = new Benchmark.Suite()

--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const AjvStandaloneCompiler = require('@fastify/ajv-compiler/standalone')
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 const urlSchema = {
   oneOf: [

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const assert = require('assert')
+const assert = require('node:assert')
 const Request = require('./lib/request')
 const Response = require('./lib/response')
 

--- a/lib/parse-url.js
+++ b/lib/parse-url.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { URL } = require('url')
+const { URL } = require('node:url')
 
 const BASE_URL = 'http://localhost'
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -2,14 +2,14 @@
 
 /* eslint no-prototype-builtins: 0 */
 
-const { Readable, addAbortSignal } = require('stream')
-const util = require('util')
+const { Readable, addAbortSignal } = require('node:stream')
+const util = require('node:util')
 const cookie = require('cookie')
-const assert = require('assert')
+const assert = require('node:assert')
 const warning = require('process-warning')()
 
 const parseURL = require('./parse-url')
-const { EventEmitter } = require('events')
+const { EventEmitter } = require('node:events')
 
 // request.connectin deprecation https://nodejs.org/api/http.html#http_request_connection
 warning.create('FastifyDeprecationLightMyRequest', 'FST_LIGHTMYREQUEST_DEP01', 'You are accessing "request.connection", use "request.socket" instead.')

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const http = require('http')
-const { Writable } = require('stream')
-const util = require('util')
+const http = require('node:http')
+const { Writable } = require('node:stream')
+const util = require('node:util')
 
 const setCookie = require('set-cookie-parser')
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,11 +2,11 @@
 
 const t = require('tap')
 const test = t.test
-const { Readable, finished, pipeline } = require('stream')
-const qs = require('querystring')
-const fs = require('fs')
-const zlib = require('zlib')
-const http = require('http')
+const { Readable, finished, pipeline } = require('node:stream')
+const qs = require('node:querystring')
+const fs = require('node:fs')
+const zlib = require('node:zlib')
+const http = require('node:http')
 const eos = require('end-of-stream')
 const semver = require('semver')
 const express = require('express')


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
