### PR TITLE
chore: Fix InjectOptions type with test additions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,6 +54,7 @@ declare namespace inject {
     payload?: InjectPayload
     body?: InjectPayload
     server?: http.Server
+    autoStart?: boolean
     cookies?: { [k: string]: string },
     signal?: AbortSignal,
     Request?: object,

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -3,6 +3,10 @@ import { inject, isInjection, Response, DispatchFunc, InjectOptions, Chain } fro
 import { expectType, expectAssignable, expectNotAssignable } from 'tsd'
 
 expectAssignable<InjectOptions>({ url: '/' })
+expectAssignable<InjectOptions>({ autoStart: true })
+expectAssignable<InjectOptions>({ autoStart: false })
+expectAssignable<InjectOptions>({ validate: true })
+expectAssignable<InjectOptions>({ validate: false })
 
 const dispatch: http.RequestListener = function (req, res) {
   expectAssignable<http.IncomingMessage>(req)


### PR DESCRIPTION
### Description

Hello!

I've noticed that `autoStart` [does not appear](https://github.com/fastify/light-my-request/blob/9605a4a6e1a6620244661b9c81481ab9e916c82e/types/index.d.ts#L27-L60) in `InjectOptions` type.
 - `autoStart` has been added as a boolean
 - tests added for both `autoStart` and `validate` (boolean as well)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation ~~is changed or added~~ exists already for `autoStart` and `validate`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


#### Tests:

```
npm test

> light-my-request@5.11.0 test
> npm run lint && npm run test:unit && npm run test:typescript


> light-my-request@5.11.0 lint
> standard


> light-my-request@5.11.0 test:unit
> tap

 PASS ​ test/response.test.js 1 OK 4.565ms
 PASS ​ test/request.test.js 1 OK 7.109ms
 PASS ​ test/async-await.test.js 4 OK 32.416ms
 PASS ​ test/index.test.js 281 OK 246.504ms



  🌈 SUMMARY RESULTS 🌈


Suites:   ​4 passed​, ​4 of 4 completed​
Asserts:  ​​​287 passed​, ​of 287​
Time:​   ​521.899ms​
----------------------|---------|----------|---------|---------|-------------------
File                  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------|---------|----------|---------|---------|-------------------
All files             |     100 |      100 |     100 |     100 |
 light-my-request     |     100 |      100 |     100 |     100 |
  index.js            |     100 |      100 |     100 |     100 |
 light-my-request/lib |     100 |      100 |     100 |     100 |
  parse-url.js        |     100 |      100 |     100 |     100 |
  request.js          |     100 |      100 |     100 |     100 |
  response.js         |     100 |      100 |     100 |     100 |
----------------------|---------|----------|---------|---------|-------------------

> light-my-request@5.11.0 test:typescript
> tsd
```

#### Benchmark:

```
npm run benchmark

> light-my-request@5.11.0 benchmark
> node benchmark/benchmark.js

┌─────────┬──────────────────────────────────┬─────────────┬────────────────────┬───────────┬─────────┐
│ (index) │ Task Name                        │ ops/sec     │ Average Time (ns)  │ Margin    │ Samples │
├─────────┼──────────────────────────────────┼─────────────┼────────────────────┼───────────┼─────────┤
│ 0       │ 'Request'                        │ '799,452'   │ 1250.8561243045604 │ '±1.84%'  │ 399727  │
│ 1       │ 'Custom Request'                 │ '64,595'    │ 15480.85259149168  │ '±1.91%'  │ 32298   │
│ 2       │ 'Request With Cookies'           │ '492,454'   │ 2030.6429852903127 │ '±6.78%'  │ 246368  │
│ 3       │ 'Request With Cookies n payload' │ '586,594'   │ 1704.7546386269912 │ '±0.96%'  │ 293298  │
│ 4       │ 'ParseUrl'                       │ '2,389,541' │ 418.4902973036068  │ '±0.24%'  │ 1194771 │
│ 5       │ 'ParseUrl and query'             │ '251,974'   │ 3968.6591183286455 │ '±0.35%'  │ 125988  │
│ 6       │ 'read request body JSON'         │ '59,306'    │ 16861.64787212543  │ '±0.50%'  │ 29654   │
│ 7       │ 'read request body buffer'       │ '64,108'    │ 15598.663422243855 │ '±0.35%'  │ 32055   │
│ 8       │ 'read request body readable'     │ '52,860'    │ 18917.78082554536  │ '±0.82%'  │ 26431   │
│ 9       │ 'Response write end'             │ '91,987'    │ 10870.983563072667 │ '±11.96%' │ 45994   │
│ 10      │ 'Response writeHead end'         │ '68,895'    │ 14514.63281024087  │ '±40.83%' │ 34538   │
│ 11      │ 'base inject'                    │ '19,952'    │ 50119.469701510636 │ '±31.62%' │ 10017   │
└─────────┴──────────────────────────────────┴─────────────┴────────────────────┴───────────┴─────────┘

```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->