### PR TITLE
feat: response.stream()

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Injects a fake request into an HTTP server.
     - `rawPayload` - the raw payload as a Buffer.
     - `trailers` - an object containing the response trailers.
     - `json` - a function that parses a json response payload and returns an object.
-    - `stream` - a function that provide a `Readable` stream of response payload.
+    - `stream` - a function that provides a `Readable` stream of the response payload.
     - `cookies` - a getter that parses the `set-cookie` response header and returns an array with all the cookies and their metadata.
 
 Notes:

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Injects a fake request into an HTTP server.
     - `rawPayload` - the raw payload as a Buffer.
     - `trailers` - an object containing the response trailers.
     - `json` - a function that parses a json response payload and returns an object.
+    - `stream` - a function that provide a `Readable` stream of response payload.
     - `cookies` - a getter that parses the `set-cookie` response header and returns an array with all the cookies and their metadata.
 
 Notes:

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const http = require('node:http')
-const { Writable } = require('node:stream')
+const { Writable, Readable } = require('node:stream')
 const util = require('node:util')
 
 const setCookie = require('set-cookie-parser')
@@ -141,6 +141,11 @@ function generatePayload (response) {
   // Prepare payload parsers
   res.json = function parseJsonPayload () {
     return JSON.parse(res.payload)
+  }
+
+  // Provide stream Readable for advanced user
+  res.stream = function streamPayload () {
+    return Readable.from(response._lightMyRequest.payloadChunks)
   }
 
   return res

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import * as http from 'http'
+import { Readable } from 'stream'
 
 type HTTPMethods = 'DELETE' | 'delete' |
                    'GET' | 'get' |
@@ -87,6 +88,7 @@ declare namespace inject {
     payload: string
     body: string
     json: <T = any>() => T
+    stream: () => Readable
     cookies: Array<Cookie>
   }
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,6 +1,7 @@
 import * as http from 'http'
 import { inject, isInjection, Response, DispatchFunc, InjectOptions, Chain } from '..'
 import { expectType, expectAssignable, expectNotAssignable } from 'tsd'
+import { Readable } from 'stream'
 
 expectAssignable<InjectOptions>({ url: '/' })
 expectAssignable<InjectOptions>({ autoStart: true })
@@ -26,8 +27,10 @@ const expectResponse = function (res: Response | undefined) {
   expectType<Response>(res)
   console.log(res.payload)
   expectAssignable<Function>(res.json)
+  expectAssignable<Function>(res.stream)
   expectAssignable<http.ServerResponse>(res.raw.res)
   expectAssignable<http.IncomingMessage>(res.raw.req)
+  expectType<Readable>(res.stream())
   expectType<string>(res.payload)
   expectType<string>(res.body)
   expectAssignable<Array<any>>(res.cookies)


### PR DESCRIPTION
Provide `Readable` response through `response.stream()`

Closes #283 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
