### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
-import * as http from 'http'
-import { Readable } from 'stream'
+import * as http from 'node:http'
+import { Readable } from 'node:stream'
 
 type HTTPMethods = 'DELETE' | 'delete' |
                    'GET' | 'get' |

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,7 +1,7 @@
-import * as http from 'http'
+import * as http from 'node:http'
 import { inject, isInjection, Response, DispatchFunc, InjectOptions, Chain } from '..'
 import { expectType, expectAssignable, expectNotAssignable } from 'tsd'
-import { Readable } from 'stream'
+import { Readable } from 'node:stream'
 
 expectAssignable<InjectOptions>({ url: '/' })
 expectAssignable<InjectOptions>({ autoStart: true })


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.