### PR TITLE
Support backpressure when streaming the payload

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -109,11 +109,11 @@ Response.prototype.write = function (data, encoding, callback) {
   }
   http.ServerResponse.prototype.write.call(this, data, encoding, callback)
   if (this._lightMyRequest.stream) {
-    this._lightMyRequest.stream.push(Buffer.from(data, encoding))
+    return this._lightMyRequest.stream.push(Buffer.from(data, encoding))
   } else {
     this._lightMyRequest.payloadChunks.push(Buffer.from(data, encoding))
+    return true
   }
-  return true
 }
 
 Response.prototype.end = function (data, encoding, callback) {


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
