### PR TITLE
Actually emit drain when backpressure kicks in

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -10,7 +10,8 @@ function Response (req, onEnd, reject) {
   http.ServerResponse.call(this, req)
 
   if (req._lightMyRequest?.payloadAsStream) {
-    this._lightMyRequest = { headers: null, trailers: {}, stream: new Readable({ read () {} }) }
+    const read = this.emit.bind(this, 'drain')
+    this._lightMyRequest = { headers: null, trailers: {}, stream: new Readable({ read }) }
     const signal = req._lightMyRequest.signal
 
     if (signal) {

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -109,7 +109,9 @@ test('stream mode - backpressure', (t, done) => {
     const buf = Buffer.alloc(1024 * 1024).fill('b')
     t.assert.strictEqual(res.write(buf), false)
     expected = 'a' + buf.toString()
-    res.end()
+    res.on('drain', () => {
+      res.end()
+    })
   }
 
   inject(dispatch, { method: 'GET', url: '/', payloadAsStream: true }, (err, res) => {


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
