### PR TITLE
fix: restore express prototypes so injecting doesn't break http requests

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2128,6 +2128,36 @@ test("passes payload when using express' send", (t, done) => {
   })
 })
 
+test('can both inject and make HTTP requests with express', (t, done) => {
+  t.plan(5)
+
+  const app = express()
+
+  app.get('/hello', (_req, res) => {
+    res.send('some text')
+  })
+
+  const server = app.listen()
+  t.after(() => server.close())
+
+  inject(app, { method: 'GET', url: 'http://example.com:8080/hello' }, (err, res) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.headers['content-length'], '9')
+    t.assert.strictEqual(res.payload, 'some text')
+
+    fetch(`http://localhost:${server.address().port}/hello`)
+      .then((res) => {
+        t.assert.strictEqual(res.headers.get('content-length'), '9')
+        return res.text()
+      })
+      .then(body => {
+        t.assert.strictEqual(body, 'some text')
+        done()
+      })
+      .catch((err) => done(err))
+  })
+})
+
 test('request that is destroyed errors', (t, done) => {
   t.plan(2)
   const dispatch = function (req, res) {


### PR DESCRIPTION
I'm attempting to port an internal express app test framework to use light-my-request because it hugely increases performance (thanks!), but some of the framework's plugins still need to make HTTP requests.

Currenlty the first `inject()` call will permenantly modify the app's request and response prototypes, making subsequent HTTP requests crash the server - this change fixes that by caching them and setting the back to the originals.

Ta

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
