### PR TITLE
Add `req.socket.destroy()`

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -42,6 +42,9 @@ class MockSocket extends EventEmitter {
     super()
     this.remoteAddress = remoteAddress
   }
+
+  destroy () {
+  }
 }
 
 /**

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -14,3 +14,10 @@ test('aborted property should be false', async (t) => {
 
   t.assert.strictEqual(req.aborted, false)
 })
+
+test('req.socket.destroy()', async (t) => {
+  const req = new Request({ url: 'http://localhost' })
+
+  t.assert.strictEqual(typeof req.socket.destroy, 'function')
+  t.assert.doesNotThrow(() => req.socket.destroy())
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)


This ensures invocation to `req.socket.destroy()` won't makes exception thrown as it happen before in my express app
```sh
125 |     // cannot actually respond
126 |     if (headersSent(res)) {
127 |       debug('cannot %d after headers sent', status)
128 |       if (req.socket) {
129 |         console.info('finalhandler req.socket:',req.socket)
130 |         req.socket.destroy()
                         ^
TypeError: req.socket.destroy is not a function. (In 'req.socket.destroy()', 'req.socket.destroy' is undefined)
      at <anonymous> (/app/node_modules/finalhandler/index.js:130:20)
```