### PR TITLE
ci: set workflow permissions to read-only by default

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,9 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     if: ${{ github.event.label.name == 'benchmark' }}
@@ -17,6 +20,8 @@ jobs:
     needs:
       - benchmark
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Remove benchmark label
         uses: octokit/request-action@v2.x


### PR DESCRIPTION
This PR is created by a script. Please check the changes prior to merging.

This PR adds permissions to the workflow and job level, making the workflows read-only by default, and allowing write access only at the job level via granular permissions. This is regularly flagged by CodeQL, Step Security, [OSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions), and other security tools.
This change also allows the org to go read-only everywhere, see https://github.com/fastify/avvio/pull/308#issuecomment-2765300174