### PR TITLE
chore: upgrade c8 to v11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@fastify/ajv-compiler": "^4.0.5",
     "@types/node": "^25.0.9",
-    "c8": "^10.1.3",
+    "c8": "^11.0.0",
     "end-of-stream": "^1.4.5",
     "eslint": "^9.39.2",
     "express": "^5.2.1",


### PR DESCRIPTION
Proposal:

- Upgrade `c8` dependency from `^10.1.3` to `^11.0.0` ( see here: https://github.com/bcoe/c8/releases/tag/v11.0.0 )