### PR TITLE
fix: support cookie v2.x

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -4,7 +4,7 @@
 
 const { Readable, addAbortSignal } = require('node:stream')
 const util = require('node:util')
-const cookie = require('cookie')
+const { stringifySetCookie } = require('cookie')
 const assert = require('node:assert')
 const { createDeprecation } = require('process-warning')
 
@@ -112,28 +112,29 @@ function Request (options) {
 
   for (const field in headers) {
     const fieldLowerCase = field.toLowerCase()
-    if (
-      (
-        fieldLowerCase === 'user-agent' ||
-        fieldLowerCase === 'content-type'
-      ) && headers[field] === undefined
-    ) {
+    if ((fieldLowerCase === 'user-agent' || fieldLowerCase === 'content-type') && headers[field] === undefined) {
       this.headers[fieldLowerCase] = undefined
       continue
     }
     const value = headers[field]
-    assert(value !== undefined, 'invalid value "undefined" for header ' + field)
+    assert(
+      value !== undefined,
+      'invalid value "undefined" for header ' + field
+    )
     this.headers[fieldLowerCase] = '' + value
   }
 
-  if (('user-agent' in this.headers) === false) {
+  if ('user-agent' in this.headers === false) {
     this.headers['user-agent'] = 'lightMyRequest'
   }
-  this.headers.host = this.headers.host || options.authority || hostHeaderFromURL(parsedURL)
+  this.headers.host =
+    this.headers.host || options.authority || hostHeaderFromURL(parsedURL)
 
   if (options.cookies) {
     const { cookies } = options
-    const cookieValues = Object.keys(cookies).map(key => cookie.serialize(key, cookies[key]))
+    const cookieValues = Object.keys(cookies).map((key) =>
+      stringifySetCookie({ name: key, value: cookies[key] })
+    )
     if (this.headers.cookie) {
       cookieValues.unshift(this.headers.cookie)
     }
@@ -166,14 +167,20 @@ function Request (options) {
   if (payload && typeof payload !== 'string' && !payloadResume && !Buffer.isBuffer(payload)) {
     payload = JSON.stringify(payload)
 
-    if (('content-type' in this.headers) === false) {
+    if ('content-type' in this.headers === false) {
       this.headers['content-type'] = 'application/json'
     }
   }
 
   // Set the content-length for the corresponding payload if none set
-  if (payload && !payloadResume && !Object.hasOwn(this.headers, 'content-length')) {
-    this.headers['content-length'] = (Buffer.isBuffer(payload) ? payload.length : Buffer.byteLength(payload)).toString()
+  if (
+    payload &&
+    !payloadResume &&
+    !Object.hasOwn(this.headers, 'content-length')
+  ) {
+    this.headers['content-length'] = (
+      Buffer.isBuffer(payload) ? payload.length : Buffer.byteLength(payload)
+    ).toString()
   }
 
   for (const header of Object.keys(this.headers)) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "@fastify/deepmerge": "^3.1.0",
-    "cookie": "^1.1.1",
+    "cookie": "^2.0.0",
     "process-warning": "^5.0.0",
     "set-cookie-parser": "^3.0.1"
   },


### PR DESCRIPTION
Proposal:

- Updates `light-my-request` to work with `cookie v2.x`(v2.0.0: https://github.com/jshttp/cookie/releases/tag/v2.0.0)

#### Change

- `cookie` v2 removed the `serialize(name, value, opts)` export, replacing it with `stringifySetCookie({ name, value, ...opts })`. `lib/request.js` still called `cookie.serialize(...)` to build the `Cookie` header from `options.cookies`, so any inject() call passing `cookies` threw `cookie.serialize is not a function` (500/TypeError). 


#### Notes for reviewers
- `cookie.serialize`/`.parse` were never part of this package's public API, so no back-compat wrapper was needed (unlike in @fastify/cookie).
- README didn't reference `cookie`'s API directly, so no doc changes.
- This PR should resolved this PR: https://github.com/fastify/light-my-request/pull/386 ( see error in the tests: https://github.com/fastify/light-my-request/actions/runs/28968947402/job/85959339312?pr=386#step:5:809 )
