### PR TITLE
fix(types): allow custom HTTP methods in InjectOptions.method

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2277,6 +2277,20 @@ test('query method works', (t, done) => {
   })
 })
 
+test('custom HTTP method works (e.g. registered via addHttpMethod)', (t, done) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    res.writeHead(200)
+    res.end(req.method)
+  }
+
+  inject(dispatch, { method: 'REBIND', url: '/test' }, (err, res) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.payload, 'REBIND')
+    done()
+  })
+})
+
 test('should return the file content', async (t) => {
   const multerMiddleware = multer({
     storage: multer.memoryStorage(),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,7 +7,8 @@ type HTTPMethods = 'DELETE' | 'delete' |
                    'PATCH' | 'patch' |
                    'POST' | 'post' |
                    'PUT' | 'put' |
-                   'OPTIONS' | 'options'
+                   'OPTIONS' | 'options' |
+                   (string & {})
 
 type Inject = typeof inject
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,7 @@ type HTTPMethods = 'DELETE' | 'delete' |
                    'POST' | 'post' |
                    'PUT' | 'put' |
                    'OPTIONS' | 'options' |
+                   'QUERY' | 'query' |
                    (string & {})
 
 type Inject = typeof inject

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -10,7 +10,7 @@ expect({ autoStart: true }).type.toBeAssignableTo<InjectOptions>()
 expect({ autoStart: false }).type.toBeAssignableTo<InjectOptions>()
 expect({ validate: true }).type.toBeAssignableTo<InjectOptions>()
 expect({ validate: false }).type.toBeAssignableTo<InjectOptions>()
-expect({ method: 'QUERY', url: '/' }).type.toBeAssignableTo<InjectOptions>()
+expect({ method: 'REBIND', url: '/' }).type.toBeAssignableTo<InjectOptions>()
 expect({ method: 'REBIND' }).type.toBeAssignableTo<InjectOptions>()
 
 const dispatch: http.RequestListener = function (req, res) {

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -11,6 +11,7 @@ expect({ autoStart: false }).type.toBeAssignableTo<InjectOptions>()
 expect({ validate: true }).type.toBeAssignableTo<InjectOptions>()
 expect({ validate: false }).type.toBeAssignableTo<InjectOptions>()
 expect({ method: 'QUERY', url: '/' }).type.toBeAssignableTo<InjectOptions>()
+expect({ method: 'REBIND' }).type.toBeAssignableTo<InjectOptions>()
 
 const dispatch: http.RequestListener = function (req, res) {
   expect(req).type.toBeAssignableTo<http.IncomingMessage>()

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -10,6 +10,7 @@ expect({ autoStart: true }).type.toBeAssignableTo<InjectOptions>()
 expect({ autoStart: false }).type.toBeAssignableTo<InjectOptions>()
 expect({ validate: true }).type.toBeAssignableTo<InjectOptions>()
 expect({ validate: false }).type.toBeAssignableTo<InjectOptions>()
+expect({ method: 'QUERY', url: '/' }).type.toBeAssignableTo<InjectOptions>()
 
 const dispatch: http.RequestListener = function (req, res) {
   expect(req).type.toBeAssignableTo<http.IncomingMessage>()


### PR DESCRIPTION
Widen `HTTPMethods` type to accept any string via `(string & {})` alongside the known literals, so methods registered with Fastify's addHttpMethod (e.g. 'QUERY', 'REBIND') type-check while autocomplete
for standard methods is preserved.

Fixes #385

### The change
Use the standard TypeScript "literal union + string" to widen `HTTPMethods` type in types/index.d.ts 

The (string & {}) intersection prevents TypeScript from collapsing the union down to plain string (which would lose IDE autocomplete for the known method literals), while still allowing any other string value — like a custom method registered via Fastify's addHttpMethod — to type-check.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
