### PR TITLE
feat: add isLightMyRequest to Request and Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,10 +310,10 @@ inject(dispatch)
 
 Note: The application would not respond multiple times. If you try to invoke any method after the application has responded, the application would throw an error.
 
-#### Inspect if Request or Response orignated from `light-my-requet`
+#### Inspect if Request or Response orignated from `light-my-request`
 
 Both `request` and `response` added `isLightMyRequest` property to inspect if it is originated by
-`light-my-requet`.
+`light-my-request`.
 
 ```js
 import { inject, DispatchFunc } from 'light-my-request'

--- a/README.md
+++ b/README.md
@@ -310,6 +310,28 @@ inject(dispatch)
 
 Note: The application would not respond multiple times. If you try to invoke any method after the application has responded, the application would throw an error.
 
+#### Inspect if Request or Response orignated from `light-my-requet`
+
+Both `request` and `response` added `isLightMyRequest` property to inspect if it is originated by
+`light-my-requet`.
+
+```js
+import { inject, DispatchFunc } from 'light-my-request'
+
+const dispatch: DispatchFunc = function (req, res) {
+  req.isLightMyRequest // true
+  res.isLightMyRequest // true
+  const reply = 'Hello World'
+  res.writeHead(200, { 'Content-Type': 'text/plain', 'Content-Length': reply.length })
+  res.end(reply)
+}
+
+inject(dispatch, { method: 'get', url: '/' }, (err, res) => {
+  console.log(res.payload)
+})
+```
+
+
 ## Acknowledgments
 This project has been forked from [`hapi/shot`](https://github.com/hapijs/shot) because we wanted to support *Node ≥ v4* and not only *Node ≥ v8*.
 All credits prior to commit [00a2a82](https://github.com/fastify/light-my-request/commit/00a2a82eb773b765003b6085788cc3564cd08326) go to the `hapi/shot` project [contributors](https://github.com/hapijs/shot/graphs/contributors).

--- a/lib/request.js
+++ b/lib/request.js
@@ -139,6 +139,7 @@ function Request (options) {
 
   this.headers = {}
   this.rawHeaders = []
+  this.isLightMyRequest = true
 
   const headers = options.headers || {}
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -9,6 +9,8 @@ const setCookie = require('set-cookie-parser')
 function Response (req, onEnd, reject) {
   http.ServerResponse.call(this, req)
 
+  this.isLightMyRequest = true
+
   if (req._lightMyRequest?.payloadAsStream) {
     const read = this.emit.bind(this, 'drain')
     this._lightMyRequest = { headers: null, trailers: {}, stream: new Readable({ read }) }
@@ -47,7 +49,7 @@ function Response (req, onEnd, reject) {
           err.code = 'LIGHT_ECONNRESET'
         }
         this._lightMyRequest.stream.destroy(err)
-        this._lightMyRequest.stream.on('error', () => {})
+        this._lightMyRequest.stream.on('error', () => { })
       }
       return
     }

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -16,6 +16,8 @@ test('aborted property should be false', async (t) => {
 })
 
 test('isLightMyRequest should be true', async (t) => {
+  t.plan(1)
+
   const mockReq = {
     url: 'http://localhost',
     method: 'GET',

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -14,3 +14,14 @@ test('aborted property should be false', async (t) => {
 
   t.assert.strictEqual(req.aborted, false)
 })
+
+test('isLightMyRequest should be true', async (t) => {
+  const mockReq = {
+    url: 'http://localhost',
+    method: 'GET',
+    headers: {}
+  }
+  const req = new Request(mockReq)
+
+  t.assert.strictEqual(req.isLightMyRequest, true)
+})

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -17,3 +17,12 @@ test('multiple calls to res.destroy should not be called', (t, done) => {
   res.destroy()
   res.destroy()
 })
+
+test('isLightMyRequest should be true', (t, done) => {
+  t.plan(1)
+
+  const res = new Response({})
+  t.assert.strictEqual(res.isLightMyRequest, true)
+
+  res.destroy()
+})

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -21,8 +21,9 @@ test('multiple calls to res.destroy should not be called', (t, done) => {
 test('isLightMyRequest should be true', (t, done) => {
   t.plan(1)
 
-  const res = new Response({})
+  const res = new Response({}, () => {
+    done()
+  })
   t.assert.strictEqual(res.isLightMyRequest, true)
-
   res.destroy()
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,14 +2,14 @@ import * as http from 'node:http'
 import { Readable } from 'node:stream'
 
 type HTTPMethods = 'DELETE' | 'delete' |
-                   'GET' | 'get' |
-                   'HEAD' | 'head' |
-                   'PATCH' | 'patch' |
-                   'POST' | 'post' |
-                   'PUT' | 'put' |
-                   'OPTIONS' | 'options' |
-                   'QUERY' | 'query' |
-                   (string & {})
+  'GET' | 'get' |
+  'HEAD' | 'head' |
+  'PATCH' | 'patch' |
+  'POST' | 'post' |
+  'PUT' | 'put' |
+  'OPTIONS' | 'options' |
+  'QUERY' | 'query' |
+  (string & {})
 
 type Inject = typeof inject
 
@@ -93,6 +93,7 @@ declare namespace inject {
     json: <T = any>() => T
     stream: () => Readable
     cookies: Array<Cookie>
+    isLightMyRequest: true
   }
 
   export interface Chain extends Promise<Response> {

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -2,8 +2,8 @@
 
 import * as http from 'node:http'
 import { Readable } from 'node:stream'
-import { bindInject, type BoundInjectFunction, type Chain, type DispatchFunc, inject, type InjectOptions, isInjection, type Response } from '.'
 import { expect } from 'tstyche'
+import { bindInject, type BoundInjectFunction, type Chain, type DispatchFunc, inject, type InjectOptions, isInjection, type Response } from '.'
 
 expect({ url: '/' }).type.toBeAssignableTo<InjectOptions>()
 expect({ autoStart: true }).type.toBeAssignableTo<InjectOptions>()
@@ -40,6 +40,7 @@ const expectResponse = function (res: Response | undefined) {
   expect(res.payload).type.toBe<string>()
   expect(res.body).type.toBe<string>()
   expect(res.cookies).type.toBeAssignableTo<Array<any>>()
+  expect(res.isLightMyRequest).type.toBe<true>()
 
   const cookie = res.cookies[0]
 


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify/issues/5615
Expose public property `isLightMyRequest` for inspecting if the request is originated by `light-my-request`.

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
