### PR TITLE
feat: implements injected cookies encoding respecting http state management rfc

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Injects a fake request into an HTTP server.
   - `authority` - a string specifying the HTTP HOST header value to be used if no header is provided, and the `url`
     does not include an authority component. Defaults to `'localhost'`.
   - `headers` - an optional object containing request headers. A header value may be an array of strings to simulate the same header being sent multiple times; the values are aggregated exactly as a Node.js HTTP server would expose them on `request.headers` (`set-cookie` is kept as an array, `cookie` values are joined with `'; '`, other values with `', '`), while every individual value is preserved in `request.rawHeaders`.
-  - `cookies` - an optional object containing key-value pairs that will be encoded and added to `cookie` header. If the header is already set, the data will be appended.
+  - `cookies` - cookies to encode onto the `Cookie` request header. See [Cookies](docs/cookies.md).
   - `remoteAddress` - an optional string specifying the client remote address. Defaults to `'127.0.0.1'`.
   - `payload` - an optional request payload. Can be a string, Buffer, Stream, or object. If the payload is string, Buffer or Stream is used as is as the request payload. Otherwise, it is serialized with `JSON.stringify` forcing the request to have the `Content-type` equal to `application/json`
   - `query` - an optional object or string containing query parameters.

--- a/build/build-validation.js
+++ b/build/build-validation.js
@@ -29,8 +29,24 @@ const schema = {
     url: urlSchema,
     path: urlSchema,
     cookies: {
-      type: 'object',
-      additionalProperties: true
+      anyOf: [
+        {
+          type: 'object',
+          additionalProperties: true
+        },
+        {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              value: { type: 'string' }
+            },
+            required: ['name', 'value'],
+            additionalProperties: true
+          }
+        }
+      ]
     },
     headers: {
       type: 'object',

--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -1,0 +1,32 @@
+# Cookies
+
+`options.cookies` is encoded onto the `Cookie` request header. If that header is already set, the encoded cookies are appended.
+
+It accepts:
+
+- an object of `name: value` strings (sent on every path, same as `Path=/`)
+- an object of `name: { value, path?, ... }` records
+- an array of cookie objects, such as a previous response's `res.cookies`
+
+> [!NOTE]
+> When a cookie includes `path`, it is sent only if that path matches the request URL as specified in [RFC 6265 §5.1.4](https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4) related to HTTP State Management Mechanism.
+>
+> Cookies without `path` are treated as `Path=/`.
+
+```js
+await inject(dispatch, { url: '/anywhere', cookies: { session: 'abc' } })
+
+await inject(dispatch, {
+  url: '/account/other',
+  cookies: {
+    session: 'ok',
+    scoped: { value: 'uid-cookie', path: '/account/123' }
+  }
+})
+// Cookie: session=ok
+
+const login = await inject(dispatch, { url: '/login' })
+await inject(dispatch, { url: '/account/other', cookies: login.cookies })
+```
+
+`res.cookies` parses the `Set-Cookie` response header into an array of cookie objects, including `path` and other attributes.

--- a/lib/config-validator.js
+++ b/lib/config-validator.js
@@ -4,7 +4,7 @@
 "use strict";
 module.exports = validate10;
 module.exports.default = validate10;
-const schema11 = {"type":"object","properties":{"url":{"oneOf":[{"type":"string"},{"type":"object","properties":{"protocol":{"type":"string"},"hostname":{"type":"string"},"pathname":{"type":"string"}},"additionalProperties":true,"required":["pathname"]}]},"path":{"oneOf":[{"type":"string"},{"type":"object","properties":{"protocol":{"type":"string"},"hostname":{"type":"string"},"pathname":{"type":"string"}},"additionalProperties":true,"required":["pathname"]}]},"cookies":{"type":"object","additionalProperties":true},"headers":{"type":"object","additionalProperties":true},"query":{"anyOf":[{"type":"object","additionalProperties":true},{"type":"string"}]},"simulate":{"type":"object","properties":{"end":{"type":"boolean"},"split":{"type":"boolean"},"error":{"type":"boolean"},"close":{"type":"boolean"}}},"authority":{"type":"string"},"remoteAddress":{"type":"string"},"method":{"type":"string","enum":["ACL","BIND","CHECKOUT","CONNECT","COPY","DELETE","GET","HEAD","LINK","LOCK","M-SEARCH","MERGE","MKACTIVITY","MKCALENDAR","MKCOL","MOVE","NOTIFY","OPTIONS","PATCH","POST","PROPFIND","PROPPATCH","PURGE","PUT","QUERY","REBIND","REPORT","SEARCH","SOURCE","SUBSCRIBE","TRACE","UNBIND","UNLINK","UNLOCK","UNSUBSCRIBE","acl","bind","checkout","connect","copy","delete","get","head","link","lock","m-search","merge","mkactivity","mkcalendar","mkcol","move","notify","options","patch","post","propfind","proppatch","purge","put","query","rebind","report","search","source","subscribe","trace","unbind","unlink","unlock","unsubscribe"]},"validate":{"type":"boolean"}},"additionalProperties":true,"oneOf":[{"required":["url"]},{"required":["path"]}]};
+const schema11 = {"type":"object","properties":{"url":{"oneOf":[{"type":"string"},{"type":"object","properties":{"protocol":{"type":"string"},"hostname":{"type":"string"},"pathname":{"type":"string"}},"additionalProperties":true,"required":["pathname"]}]},"path":{"oneOf":[{"type":"string"},{"type":"object","properties":{"protocol":{"type":"string"},"hostname":{"type":"string"},"pathname":{"type":"string"}},"additionalProperties":true,"required":["pathname"]}]},"cookies":{"anyOf":[{"type":"object","additionalProperties":true},{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"value":{"type":"string"}},"required":["name","value"],"additionalProperties":true}}]},"headers":{"type":"object","additionalProperties":true},"query":{"anyOf":[{"type":"object","additionalProperties":true},{"type":"string"}]},"simulate":{"type":"object","properties":{"end":{"type":"boolean"},"split":{"type":"boolean"},"error":{"type":"boolean"},"close":{"type":"boolean"}}},"authority":{"type":"string"},"remoteAddress":{"type":"string"},"method":{"type":"string","enum":["ACL","BIND","CHECKOUT","CONNECT","COPY","DELETE","GET","HEAD","LINK","LOCK","M-SEARCH","MERGE","MKACTIVITY","MKCALENDAR","MKCOL","MOVE","NOTIFY","OPTIONS","PATCH","POST","PROPFIND","PROPPATCH","PURGE","PUT","QUERY","REBIND","REPORT","SEARCH","SOURCE","SUBSCRIBE","TRACE","UNBIND","UNLINK","UNLOCK","UNSUBSCRIBE","acl","bind","checkout","connect","copy","delete","get","head","link","lock","m-search","merge","mkactivity","mkcalendar","mkcol","move","notify","options","patch","post","propfind","proppatch","purge","put","query","rebind","report","search","source","subscribe","trace","unbind","unlink","unlock","unsubscribe"]},"validate":{"type":"boolean"}},"additionalProperties":true,"oneOf":[{"required":["url"]},{"required":["path"]}]};
 
 function validate10(data, {instancePath="", parentData, parentDataProperty, rootData=data}={}){
 let vErrors = null;
@@ -524,42 +524,12 @@ if(valid1){
 if(data.cookies !== undefined){
 let data8 = data.cookies;
 const _errs31 = errors;
-if(errors === _errs31){
-if(!(data8 && typeof data8 == "object" && !Array.isArray(data8))){
-validate10.errors = [{instancePath:instancePath+"/cookies",schemaPath:"#/properties/cookies/type",keyword:"type",params:{type: "object"},message:"must be object"}];
-return false;
-}
-}
-var valid1 = _errs31 === errors;
-}
-else {
-var valid1 = true;
-}
-if(valid1){
-if(data.headers !== undefined){
-let data9 = data.headers;
-const _errs34 = errors;
-if(errors === _errs34){
-if(!(data9 && typeof data9 == "object" && !Array.isArray(data9))){
-validate10.errors = [{instancePath:instancePath+"/headers",schemaPath:"#/properties/headers/type",keyword:"type",params:{type: "object"},message:"must be object"}];
-return false;
-}
-}
-var valid1 = _errs34 === errors;
-}
-else {
-var valid1 = true;
-}
-if(valid1){
-if(data.query !== undefined){
-let data10 = data.query;
-const _errs37 = errors;
-const _errs38 = errors;
+const _errs32 = errors;
 let valid6 = false;
-const _errs39 = errors;
-if(errors === _errs39){
-if(!(data10 && typeof data10 == "object" && !Array.isArray(data10))){
-const err17 = {instancePath:instancePath+"/query",schemaPath:"#/properties/query/anyOf/0/type",keyword:"type",params:{type: "object"},message:"must be object"};
+const _errs33 = errors;
+if(errors === _errs33){
+if(!(data8 && typeof data8 == "object" && !Array.isArray(data8))){
+const err17 = {instancePath:instancePath+"/cookies",schemaPath:"#/properties/cookies/anyOf/0/type",keyword:"type",params:{type: "object"},message:"must be object"};
 if(vErrors === null){
 vErrors = [err17];
 }
@@ -569,10 +539,34 @@ vErrors.push(err17);
 errors++;
 }
 }
-var _valid3 = _errs39 === errors;
+var _valid3 = _errs33 === errors;
 valid6 = valid6 || _valid3;
 if(!valid6){
-const _errs42 = errors;
+const _errs36 = errors;
+if(errors === _errs36){
+if(Array.isArray(data8)){
+var valid7 = true;
+const len0 = data8.length;
+for(let i0=0; i0<len0; i0++){
+let data9 = data8[i0];
+const _errs38 = errors;
+if(errors === _errs38){
+if(data9 && typeof data9 == "object" && !Array.isArray(data9)){
+let missing4;
+if(((data9.name === undefined) && (missing4 = "name")) || ((data9.value === undefined) && (missing4 = "value"))){
+const err18 = {instancePath:instancePath+"/cookies/" + i0,schemaPath:"#/properties/cookies/anyOf/1/items/required",keyword:"required",params:{missingProperty: missing4},message:"must have required property '"+missing4+"'"};
+if(vErrors === null){
+vErrors = [err18];
+}
+else {
+vErrors.push(err18);
+}
+errors++;
+}
+else {
+if(data9.name !== undefined){
+let data10 = data9.name;
+const _errs41 = errors;
 if(typeof data10 !== "string"){
 let dataType8 = typeof data10;
 let coerced8 = undefined;
@@ -584,28 +578,7 @@ else if(data10 === null){
 coerced8 = "";
 }
 else {
-const err18 = {instancePath:instancePath+"/query",schemaPath:"#/properties/query/anyOf/1/type",keyword:"type",params:{type: "string"},message:"must be string"};
-if(vErrors === null){
-vErrors = [err18];
-}
-else {
-vErrors.push(err18);
-}
-errors++;
-}
-}
-if(coerced8 !== undefined){
-data10 = coerced8;
-if(data !== undefined){
-data["query"] = coerced8;
-}
-}
-}
-var _valid3 = _errs42 === errors;
-valid6 = valid6 || _valid3;
-}
-if(!valid6){
-const err19 = {instancePath:instancePath+"/query",schemaPath:"#/properties/query/anyOf",keyword:"anyOf",params:{},message:"must match a schema in anyOf"};
+const err19 = {instancePath:instancePath+"/cookies/" + i0+"/name",schemaPath:"#/properties/cookies/anyOf/1/items/properties/name/type",keyword:"type",params:{type: "string"},message:"must be string"};
 if(vErrors === null){
 vErrors = [err19];
 }
@@ -613,149 +586,340 @@ else {
 vErrors.push(err19);
 }
 errors++;
+}
+}
+if(coerced8 !== undefined){
+data10 = coerced8;
+if(data9 !== undefined){
+data9["name"] = coerced8;
+}
+}
+}
+var valid8 = _errs41 === errors;
+}
+else {
+var valid8 = true;
+}
+if(valid8){
+if(data9.value !== undefined){
+let data11 = data9.value;
+const _errs43 = errors;
+if(typeof data11 !== "string"){
+let dataType9 = typeof data11;
+let coerced9 = undefined;
+if(!(coerced9 !== undefined)){
+if(dataType9 == "number" || dataType9 == "boolean"){
+coerced9 = "" + data11;
+}
+else if(data11 === null){
+coerced9 = "";
+}
+else {
+const err20 = {instancePath:instancePath+"/cookies/" + i0+"/value",schemaPath:"#/properties/cookies/anyOf/1/items/properties/value/type",keyword:"type",params:{type: "string"},message:"must be string"};
+if(vErrors === null){
+vErrors = [err20];
+}
+else {
+vErrors.push(err20);
+}
+errors++;
+}
+}
+if(coerced9 !== undefined){
+data11 = coerced9;
+if(data9 !== undefined){
+data9["value"] = coerced9;
+}
+}
+}
+var valid8 = _errs43 === errors;
+}
+else {
+var valid8 = true;
+}
+}
+}
+}
+else {
+const err21 = {instancePath:instancePath+"/cookies/" + i0,schemaPath:"#/properties/cookies/anyOf/1/items/type",keyword:"type",params:{type: "object"},message:"must be object"};
+if(vErrors === null){
+vErrors = [err21];
+}
+else {
+vErrors.push(err21);
+}
+errors++;
+}
+}
+var valid7 = _errs38 === errors;
+if(!valid7){
+break;
+}
+}
+}
+else {
+const err22 = {instancePath:instancePath+"/cookies",schemaPath:"#/properties/cookies/anyOf/1/type",keyword:"type",params:{type: "array"},message:"must be array"};
+if(vErrors === null){
+vErrors = [err22];
+}
+else {
+vErrors.push(err22);
+}
+errors++;
+}
+}
+var _valid3 = _errs36 === errors;
+valid6 = valid6 || _valid3;
+}
+if(!valid6){
+const err23 = {instancePath:instancePath+"/cookies",schemaPath:"#/properties/cookies/anyOf",keyword:"anyOf",params:{},message:"must match a schema in anyOf"};
+if(vErrors === null){
+vErrors = [err23];
+}
+else {
+vErrors.push(err23);
+}
+errors++;
 validate10.errors = vErrors;
 return false;
 }
 else {
-errors = _errs38;
+errors = _errs32;
 if(vErrors !== null){
-if(_errs38){
-vErrors.length = _errs38;
+if(_errs32){
+vErrors.length = _errs32;
 }
 else {
 vErrors = null;
 }
 }
 }
-var valid1 = _errs37 === errors;
+var valid1 = _errs31 === errors;
+}
+else {
+var valid1 = true;
+}
+if(valid1){
+if(data.headers !== undefined){
+let data12 = data.headers;
+const _errs45 = errors;
+if(errors === _errs45){
+if(!(data12 && typeof data12 == "object" && !Array.isArray(data12))){
+validate10.errors = [{instancePath:instancePath+"/headers",schemaPath:"#/properties/headers/type",keyword:"type",params:{type: "object"},message:"must be object"}];
+return false;
+}
+}
+var valid1 = _errs45 === errors;
+}
+else {
+var valid1 = true;
+}
+if(valid1){
+if(data.query !== undefined){
+let data13 = data.query;
+const _errs48 = errors;
+const _errs49 = errors;
+let valid9 = false;
+const _errs50 = errors;
+if(errors === _errs50){
+if(!(data13 && typeof data13 == "object" && !Array.isArray(data13))){
+const err24 = {instancePath:instancePath+"/query",schemaPath:"#/properties/query/anyOf/0/type",keyword:"type",params:{type: "object"},message:"must be object"};
+if(vErrors === null){
+vErrors = [err24];
+}
+else {
+vErrors.push(err24);
+}
+errors++;
+}
+}
+var _valid4 = _errs50 === errors;
+valid9 = valid9 || _valid4;
+if(!valid9){
+const _errs53 = errors;
+if(typeof data13 !== "string"){
+let dataType10 = typeof data13;
+let coerced10 = undefined;
+if(!(coerced10 !== undefined)){
+if(dataType10 == "number" || dataType10 == "boolean"){
+coerced10 = "" + data13;
+}
+else if(data13 === null){
+coerced10 = "";
+}
+else {
+const err25 = {instancePath:instancePath+"/query",schemaPath:"#/properties/query/anyOf/1/type",keyword:"type",params:{type: "string"},message:"must be string"};
+if(vErrors === null){
+vErrors = [err25];
+}
+else {
+vErrors.push(err25);
+}
+errors++;
+}
+}
+if(coerced10 !== undefined){
+data13 = coerced10;
+if(data !== undefined){
+data["query"] = coerced10;
+}
+}
+}
+var _valid4 = _errs53 === errors;
+valid9 = valid9 || _valid4;
+}
+if(!valid9){
+const err26 = {instancePath:instancePath+"/query",schemaPath:"#/properties/query/anyOf",keyword:"anyOf",params:{},message:"must match a schema in anyOf"};
+if(vErrors === null){
+vErrors = [err26];
+}
+else {
+vErrors.push(err26);
+}
+errors++;
+validate10.errors = vErrors;
+return false;
+}
+else {
+errors = _errs49;
+if(vErrors !== null){
+if(_errs49){
+vErrors.length = _errs49;
+}
+else {
+vErrors = null;
+}
+}
+}
+var valid1 = _errs48 === errors;
 }
 else {
 var valid1 = true;
 }
 if(valid1){
 if(data.simulate !== undefined){
-let data11 = data.simulate;
-const _errs44 = errors;
-if(errors === _errs44){
-if(data11 && typeof data11 == "object" && !Array.isArray(data11)){
-if(data11.end !== undefined){
-let data12 = data11.end;
-const _errs46 = errors;
-if(typeof data12 !== "boolean"){
-let coerced9 = undefined;
-if(!(coerced9 !== undefined)){
-if(data12 === "false" || data12 === 0 || data12 === null){
-coerced9 = false;
+let data14 = data.simulate;
+const _errs55 = errors;
+if(errors === _errs55){
+if(data14 && typeof data14 == "object" && !Array.isArray(data14)){
+if(data14.end !== undefined){
+let data15 = data14.end;
+const _errs57 = errors;
+if(typeof data15 !== "boolean"){
+let coerced11 = undefined;
+if(!(coerced11 !== undefined)){
+if(data15 === "false" || data15 === 0 || data15 === null){
+coerced11 = false;
 }
-else if(data12 === "true" || data12 === 1){
-coerced9 = true;
+else if(data15 === "true" || data15 === 1){
+coerced11 = true;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/simulate/end",schemaPath:"#/properties/simulate/properties/end/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
-if(coerced9 !== undefined){
-data12 = coerced9;
-if(data11 !== undefined){
-data11["end"] = coerced9;
+if(coerced11 !== undefined){
+data15 = coerced11;
+if(data14 !== undefined){
+data14["end"] = coerced11;
 }
 }
 }
-var valid7 = _errs46 === errors;
+var valid10 = _errs57 === errors;
 }
 else {
-var valid7 = true;
+var valid10 = true;
 }
-if(valid7){
-if(data11.split !== undefined){
-let data13 = data11.split;
-const _errs48 = errors;
-if(typeof data13 !== "boolean"){
-let coerced10 = undefined;
-if(!(coerced10 !== undefined)){
-if(data13 === "false" || data13 === 0 || data13 === null){
-coerced10 = false;
+if(valid10){
+if(data14.split !== undefined){
+let data16 = data14.split;
+const _errs59 = errors;
+if(typeof data16 !== "boolean"){
+let coerced12 = undefined;
+if(!(coerced12 !== undefined)){
+if(data16 === "false" || data16 === 0 || data16 === null){
+coerced12 = false;
 }
-else if(data13 === "true" || data13 === 1){
-coerced10 = true;
+else if(data16 === "true" || data16 === 1){
+coerced12 = true;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/simulate/split",schemaPath:"#/properties/simulate/properties/split/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
-if(coerced10 !== undefined){
-data13 = coerced10;
-if(data11 !== undefined){
-data11["split"] = coerced10;
+if(coerced12 !== undefined){
+data16 = coerced12;
+if(data14 !== undefined){
+data14["split"] = coerced12;
 }
 }
 }
-var valid7 = _errs48 === errors;
+var valid10 = _errs59 === errors;
 }
 else {
-var valid7 = true;
+var valid10 = true;
 }
-if(valid7){
-if(data11.error !== undefined){
-let data14 = data11.error;
-const _errs50 = errors;
-if(typeof data14 !== "boolean"){
-let coerced11 = undefined;
-if(!(coerced11 !== undefined)){
-if(data14 === "false" || data14 === 0 || data14 === null){
-coerced11 = false;
+if(valid10){
+if(data14.error !== undefined){
+let data17 = data14.error;
+const _errs61 = errors;
+if(typeof data17 !== "boolean"){
+let coerced13 = undefined;
+if(!(coerced13 !== undefined)){
+if(data17 === "false" || data17 === 0 || data17 === null){
+coerced13 = false;
 }
-else if(data14 === "true" || data14 === 1){
-coerced11 = true;
+else if(data17 === "true" || data17 === 1){
+coerced13 = true;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/simulate/error",schemaPath:"#/properties/simulate/properties/error/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
-if(coerced11 !== undefined){
-data14 = coerced11;
-if(data11 !== undefined){
-data11["error"] = coerced11;
+if(coerced13 !== undefined){
+data17 = coerced13;
+if(data14 !== undefined){
+data14["error"] = coerced13;
 }
 }
 }
-var valid7 = _errs50 === errors;
+var valid10 = _errs61 === errors;
 }
 else {
-var valid7 = true;
+var valid10 = true;
 }
-if(valid7){
-if(data11.close !== undefined){
-let data15 = data11.close;
-const _errs52 = errors;
-if(typeof data15 !== "boolean"){
-let coerced12 = undefined;
-if(!(coerced12 !== undefined)){
-if(data15 === "false" || data15 === 0 || data15 === null){
-coerced12 = false;
+if(valid10){
+if(data14.close !== undefined){
+let data18 = data14.close;
+const _errs63 = errors;
+if(typeof data18 !== "boolean"){
+let coerced14 = undefined;
+if(!(coerced14 !== undefined)){
+if(data18 === "false" || data18 === 0 || data18 === null){
+coerced14 = false;
 }
-else if(data15 === "true" || data15 === 1){
-coerced12 = true;
+else if(data18 === "true" || data18 === 1){
+coerced14 = true;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/simulate/close",schemaPath:"#/properties/simulate/properties/close/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
-if(coerced12 !== undefined){
-data15 = coerced12;
-if(data11 !== undefined){
-data11["close"] = coerced12;
+if(coerced14 !== undefined){
+data18 = coerced14;
+if(data14 !== undefined){
+data14["close"] = coerced14;
 }
 }
 }
-var valid7 = _errs52 === errors;
+var valid10 = _errs63 === errors;
 }
 else {
-var valid7 = true;
+var valid10 = true;
 }
 }
 }
@@ -766,134 +930,134 @@ validate10.errors = [{instancePath:instancePath+"/simulate",schemaPath:"#/proper
 return false;
 }
 }
-var valid1 = _errs44 === errors;
+var valid1 = _errs55 === errors;
 }
 else {
 var valid1 = true;
 }
 if(valid1){
 if(data.authority !== undefined){
-let data16 = data.authority;
-const _errs54 = errors;
-if(typeof data16 !== "string"){
-let dataType13 = typeof data16;
-let coerced13 = undefined;
-if(!(coerced13 !== undefined)){
-if(dataType13 == "number" || dataType13 == "boolean"){
-coerced13 = "" + data16;
+let data19 = data.authority;
+const _errs65 = errors;
+if(typeof data19 !== "string"){
+let dataType15 = typeof data19;
+let coerced15 = undefined;
+if(!(coerced15 !== undefined)){
+if(dataType15 == "number" || dataType15 == "boolean"){
+coerced15 = "" + data19;
 }
-else if(data16 === null){
-coerced13 = "";
+else if(data19 === null){
+coerced15 = "";
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/authority",schemaPath:"#/properties/authority/type",keyword:"type",params:{type: "string"},message:"must be string"}];
 return false;
 }
 }
-if(coerced13 !== undefined){
-data16 = coerced13;
+if(coerced15 !== undefined){
+data19 = coerced15;
 if(data !== undefined){
-data["authority"] = coerced13;
+data["authority"] = coerced15;
 }
 }
 }
-var valid1 = _errs54 === errors;
+var valid1 = _errs65 === errors;
 }
 else {
 var valid1 = true;
 }
 if(valid1){
 if(data.remoteAddress !== undefined){
-let data17 = data.remoteAddress;
-const _errs56 = errors;
-if(typeof data17 !== "string"){
-let dataType14 = typeof data17;
-let coerced14 = undefined;
-if(!(coerced14 !== undefined)){
-if(dataType14 == "number" || dataType14 == "boolean"){
-coerced14 = "" + data17;
+let data20 = data.remoteAddress;
+const _errs67 = errors;
+if(typeof data20 !== "string"){
+let dataType16 = typeof data20;
+let coerced16 = undefined;
+if(!(coerced16 !== undefined)){
+if(dataType16 == "number" || dataType16 == "boolean"){
+coerced16 = "" + data20;
 }
-else if(data17 === null){
-coerced14 = "";
+else if(data20 === null){
+coerced16 = "";
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/remoteAddress",schemaPath:"#/properties/remoteAddress/type",keyword:"type",params:{type: "string"},message:"must be string"}];
 return false;
 }
 }
-if(coerced14 !== undefined){
-data17 = coerced14;
+if(coerced16 !== undefined){
+data20 = coerced16;
 if(data !== undefined){
-data["remoteAddress"] = coerced14;
+data["remoteAddress"] = coerced16;
 }
 }
 }
-var valid1 = _errs56 === errors;
+var valid1 = _errs67 === errors;
 }
 else {
 var valid1 = true;
 }
 if(valid1){
 if(data.method !== undefined){
-let data18 = data.method;
-const _errs58 = errors;
-if(typeof data18 !== "string"){
-let dataType15 = typeof data18;
-let coerced15 = undefined;
-if(!(coerced15 !== undefined)){
-if(dataType15 == "number" || dataType15 == "boolean"){
-coerced15 = "" + data18;
+let data21 = data.method;
+const _errs69 = errors;
+if(typeof data21 !== "string"){
+let dataType17 = typeof data21;
+let coerced17 = undefined;
+if(!(coerced17 !== undefined)){
+if(dataType17 == "number" || dataType17 == "boolean"){
+coerced17 = "" + data21;
 }
-else if(data18 === null){
-coerced15 = "";
+else if(data21 === null){
+coerced17 = "";
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/method",schemaPath:"#/properties/method/type",keyword:"type",params:{type: "string"},message:"must be string"}];
 return false;
 }
 }
-if(coerced15 !== undefined){
-data18 = coerced15;
+if(coerced17 !== undefined){
+data21 = coerced17;
 if(data !== undefined){
-data["method"] = coerced15;
+data["method"] = coerced17;
 }
 }
 }
-if(!((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((data18 === "ACL") || (data18 === "BIND")) || (data18 === "CHECKOUT")) || (data18 === "CONNECT")) || (data18 === "COPY")) || (data18 === "DELETE")) || (data18 === "GET")) || (data18 === "HEAD")) || (data18 === "LINK")) || (data18 === "LOCK")) || (data18 === "M-SEARCH")) || (data18 === "MERGE")) || (data18 === "MKACTIVITY")) || (data18 === "MKCALENDAR")) || (data18 === "MKCOL")) || (data18 === "MOVE")) || (data18 === "NOTIFY")) || (data18 === "OPTIONS")) || (data18 === "PATCH")) || (data18 === "POST")) || (data18 === "PROPFIND")) || (data18 === "PROPPATCH")) || (data18 === "PURGE")) || (data18 === "PUT")) || (data18 === "QUERY")) || (data18 === "REBIND")) || (data18 === "REPORT")) || (data18 === "SEARCH")) || (data18 === "SOURCE")) || (data18 === "SUBSCRIBE")) || (data18 === "TRACE")) || (data18 === "UNBIND")) || (data18 === "UNLINK")) || (data18 === "UNLOCK")) || (data18 === "UNSUBSCRIBE")) || (data18 === "acl")) || (data18 === "bind")) || (data18 === "checkout")) || (data18 === "connect")) || (data18 === "copy")) || (data18 === "delete")) || (data18 === "get")) || (data18 === "head")) || (data18 === "link")) || (data18 === "lock")) || (data18 === "m-search")) || (data18 === "merge")) || (data18 === "mkactivity")) || (data18 === "mkcalendar")) || (data18 === "mkcol")) || (data18 === "move")) || (data18 === "notify")) || (data18 === "options")) || (data18 === "patch")) || (data18 === "post")) || (data18 === "propfind")) || (data18 === "proppatch")) || (data18 === "purge")) || (data18 === "put")) || (data18 === "query")) || (data18 === "rebind")) || (data18 === "report")) || (data18 === "search")) || (data18 === "source")) || (data18 === "subscribe")) || (data18 === "trace")) || (data18 === "unbind")) || (data18 === "unlink")) || (data18 === "unlock")) || (data18 === "unsubscribe"))){
+if(!((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((data21 === "ACL") || (data21 === "BIND")) || (data21 === "CHECKOUT")) || (data21 === "CONNECT")) || (data21 === "COPY")) || (data21 === "DELETE")) || (data21 === "GET")) || (data21 === "HEAD")) || (data21 === "LINK")) || (data21 === "LOCK")) || (data21 === "M-SEARCH")) || (data21 === "MERGE")) || (data21 === "MKACTIVITY")) || (data21 === "MKCALENDAR")) || (data21 === "MKCOL")) || (data21 === "MOVE")) || (data21 === "NOTIFY")) || (data21 === "OPTIONS")) || (data21 === "PATCH")) || (data21 === "POST")) || (data21 === "PROPFIND")) || (data21 === "PROPPATCH")) || (data21 === "PURGE")) || (data21 === "PUT")) || (data21 === "QUERY")) || (data21 === "REBIND")) || (data21 === "REPORT")) || (data21 === "SEARCH")) || (data21 === "SOURCE")) || (data21 === "SUBSCRIBE")) || (data21 === "TRACE")) || (data21 === "UNBIND")) || (data21 === "UNLINK")) || (data21 === "UNLOCK")) || (data21 === "UNSUBSCRIBE")) || (data21 === "acl")) || (data21 === "bind")) || (data21 === "checkout")) || (data21 === "connect")) || (data21 === "copy")) || (data21 === "delete")) || (data21 === "get")) || (data21 === "head")) || (data21 === "link")) || (data21 === "lock")) || (data21 === "m-search")) || (data21 === "merge")) || (data21 === "mkactivity")) || (data21 === "mkcalendar")) || (data21 === "mkcol")) || (data21 === "move")) || (data21 === "notify")) || (data21 === "options")) || (data21 === "patch")) || (data21 === "post")) || (data21 === "propfind")) || (data21 === "proppatch")) || (data21 === "purge")) || (data21 === "put")) || (data21 === "query")) || (data21 === "rebind")) || (data21 === "report")) || (data21 === "search")) || (data21 === "source")) || (data21 === "subscribe")) || (data21 === "trace")) || (data21 === "unbind")) || (data21 === "unlink")) || (data21 === "unlock")) || (data21 === "unsubscribe"))){
 validate10.errors = [{instancePath:instancePath+"/method",schemaPath:"#/properties/method/enum",keyword:"enum",params:{allowedValues: schema11.properties.method.enum},message:"must be equal to one of the allowed values"}];
 return false;
 }
-var valid1 = _errs58 === errors;
+var valid1 = _errs69 === errors;
 }
 else {
 var valid1 = true;
 }
 if(valid1){
 if(data.validate !== undefined){
-let data19 = data.validate;
-const _errs60 = errors;
-if(typeof data19 !== "boolean"){
-let coerced16 = undefined;
-if(!(coerced16 !== undefined)){
-if(data19 === "false" || data19 === 0 || data19 === null){
-coerced16 = false;
+let data22 = data.validate;
+const _errs71 = errors;
+if(typeof data22 !== "boolean"){
+let coerced18 = undefined;
+if(!(coerced18 !== undefined)){
+if(data22 === "false" || data22 === 0 || data22 === null){
+coerced18 = false;
 }
-else if(data19 === "true" || data19 === 1){
-coerced16 = true;
+else if(data22 === "true" || data22 === 1){
+coerced18 = true;
 }
 else {
 validate10.errors = [{instancePath:instancePath+"/validate",schemaPath:"#/properties/validate/type",keyword:"type",params:{type: "boolean"},message:"must be boolean"}];
 return false;
 }
 }
-if(coerced16 !== undefined){
-data19 = coerced16;
+if(coerced18 !== undefined){
+data22 = coerced18;
 if(data !== undefined){
-data["validate"] = coerced16;
+data["validate"] = coerced18;
 }
 }
 }
-var valid1 = _errs60 === errors;
+var valid1 = _errs71 === errors;
 }
 else {
 var valid1 = true;

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const { stringifySetCookie } = require('cookie')
+
+/**
+ * RFC 6265 §5.1.4 cookie-path matching.
+ *
+ * A cookie with no Path is treated as "/", matching every request path.
+ *
+ * @param {string | undefined} cookiePath
+ * @param {string} requestPath
+ * @return {boolean}
+ */
+function cookiePathMatches (cookiePath, requestPath) {
+  const path = cookiePath || '/'
+  if (requestPath === path) {
+    return true
+  }
+  if (!requestPath.startsWith(path)) {
+    return false
+  }
+  return path.endsWith('/') || requestPath.charAt(path.length) === '/'
+}
+
+/**
+ * Normalize `options.cookies` to `{ name, value, path? }` records.
+ *
+ * @param {object | Array<object>} cookies
+ * @return {Array<{ name: string, value: string, path?: string }>}
+ */
+function listCookies (cookies) {
+  if (Array.isArray(cookies)) {
+    return cookies
+  }
+  return Object.keys(cookies).map((name) => {
+    const item = cookies[name]
+    if (item !== null && typeof item === 'object') {
+      return {
+        name: item.name || name,
+        value: item.value,
+        path: item.path
+      }
+    }
+    return { name, value: item }
+  })
+}
+
+/**
+ * Encode cookies for the request Cookie header, omitting those whose Path
+ * does not match the request URL.
+ *
+ * @param {object | Array<object>} cookies
+ * @param {string} requestPath
+ * @return {string[]}
+ */
+function encodeCookies (cookies, requestPath) {
+  return listCookies(cookies)
+    .filter((item) => cookiePathMatches(item.path, requestPath))
+    .map((item) => stringifySetCookie({ name: item.name, value: item.value }))
+}
+
+module.exports = {
+  cookiePathMatches,
+  encodeCookies,
+  listCookies
+}

--- a/lib/request.js
+++ b/lib/request.js
@@ -4,10 +4,10 @@
 
 const { Readable, addAbortSignal } = require('node:stream')
 const util = require('node:util')
-const { stringifySetCookie } = require('cookie')
 const assert = require('node:assert')
 const { createDeprecation } = require('process-warning')
 
+const { encodeCookies } = require('./cookies')
 const parseURL = require('./parse-url')
 const { isFormDataLike, formDataToStream } = require('./form-data')
 const { EventEmitter } = require('node:events')
@@ -183,10 +183,7 @@ function Request (options) {
     this.headers.host || options.authority || hostHeaderFromURL(parsedURL)
 
   if (options.cookies) {
-    const { cookies } = options
-    const cookieValues = Object.keys(cookies).map((key) =>
-      stringifySetCookie({ name: key, value: cookies[key] })
-    )
+    const cookieValues = encodeCookies(options.cookies, parsedURL.pathname)
     if (this.headers.cookie) {
       cookieValues.unshift(this.headers.cookie)
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1647,6 +1647,96 @@ test('send cookie', (t, done) => {
   })
 })
 
+test('send cookie omits Path that does not match the request URL', (t, done) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end(req.headers.cookie || '')
+  }
+
+  inject(dispatch, {
+    url: '/account/other',
+    cookies: {
+      session: 'ok',
+      scoped: { value: 'uid-cookie', path: '/account/123' }
+    }
+  }, (err, res) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.payload, 'session=ok')
+    done()
+  })
+})
+
+test('send cookie includes Path that matches the request URL', (t, done) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end(req.headers.cookie || '')
+  }
+
+  inject(dispatch, {
+    url: '/account/123/settings',
+    cookies: {
+      session: 'ok',
+      scoped: { value: 'uid-cookie', path: '/account/123' }
+    }
+  }, (err, res) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.payload, 'session=ok; scoped=uid-cookie')
+    done()
+  })
+})
+
+test('send cookie honors RFC 6265 path-prefix matching', (t, done) => {
+  t.plan(2)
+  const dispatch = function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end(req.headers.cookie || '')
+  }
+
+  inject(dispatch, {
+    url: '/docsets',
+    cookies: {
+      docs: { value: '1', path: '/docs' },
+      slash: { value: '2', path: '/docs/' },
+      all: { value: '3', path: '/' }
+    }
+  }, (err, res) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.payload, 'all=3')
+    done()
+  })
+})
+
+test('send cookie accepts a previous response cookie array', (t, done) => {
+  t.plan(3)
+  const dispatch = function (req, res) {
+    if (req.url === '/login') {
+      res.setHeader('Set-Cookie', [
+        'session=abc; Path=/',
+        'scoped=uid; Path=/account/123'
+      ])
+      res.writeHead(200)
+      res.end()
+      return
+    }
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end(req.headers.cookie || '')
+  }
+
+  inject(dispatch, { url: '/login' }, (err, login) => {
+    t.assert.ifError(err)
+    inject(dispatch, {
+      url: '/account/other',
+      cookies: login.cookies
+    }, (err, res) => {
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.payload, 'session=abc')
+      done()
+    })
+  })
+})
+
 test('send cookie with header already set', (t, done) => {
   t.plan(3)
   const dispatch = function (req, res) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -58,7 +58,7 @@ declare namespace inject {
     body?: InjectPayload
     server?: http.Server
     autoStart?: boolean
-    cookies?: { [k: string]: string },
+    cookies?: { [k: string]: string | Omit<Cookie, 'name'> } | Cookie[],
     signal?: AbortSignal,
     Request?: object,
     payloadAsStream?: boolean
@@ -67,9 +67,11 @@ declare namespace inject {
   /**
    * https://github.com/nfriedly/set-cookie-parser/blob/3eab8b7d5d12c8ed87832532861c1a35520cf5b3/lib/set-cookie.js#L41
    */
-  interface Cookie {
+  export interface Cookie {
     name: string;
     value: string;
+    path?: string;
+    domain?: string;
     expires?: Date;
     maxAge?: number;
     secure?: boolean;
@@ -109,7 +111,7 @@ declare namespace inject {
     headers: (headers: http.IncomingHttpHeaders | http.OutgoingHttpHeaders) => Chain
     payload: (payload: InjectPayload) => Chain
     query: (query: string | { [k: string]: string | string[] }) => Chain
-    cookies: (query: object) => Chain
+    cookies: (cookies: InjectOptions['cookies']) => Chain
     end(): Promise<Response>
     end(callback: CallbackFunc): void
   }

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -47,6 +47,8 @@ const expectResponse = function (res: Response | undefined) {
   if (cookie) {
     expect(cookie.name).type.toBe<string>()
     expect(cookie.value).type.toBe<string>()
+    expect(cookie.path).type.toBe<string | undefined>()
+    expect(cookie.domain).type.toBe<string | undefined>()
     expect(cookie.expires).type.toBe<Date | undefined>()
     expect(cookie.maxAge).type.toBe<number | undefined>()
     expect(cookie.httpOnly).type.toBe<boolean | undefined>()
@@ -77,6 +79,23 @@ inject(dispatch, { method: 'get', url }, (err, res) => {
 })
 
 inject(dispatch, { method: 'get', url: '/', cookies: { name1: 'value1', value2: 'value2' } }, (err, res) => {
+  expect(err).type.toBe<Error | undefined>()
+  expectResponse(res)
+})
+
+inject(dispatch, {
+  method: 'get',
+  url: '/',
+  cookies: {
+    session: 'abc',
+    scoped: { value: 'uid', path: '/admin' }
+  }
+}, (err, res) => {
+  expect(err).type.toBe<Error | undefined>()
+  expectResponse(res)
+})
+
+inject(dispatch, { method: 'get', url: '/', cookies: [{ name: 'session', value: 'abc', path: '/' }] }, (err, res) => {
   expect(err).type.toBe<Error | undefined>()
   expectResponse(res)
 })


### PR DESCRIPTION
## Summary
- `inject({ cookies })` now encodes cookies onto the `Cookie` header using [RFC 6265 §5.1.4](https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4) path matching, so a cookie with `Path=/account/123` is not sent to `/account/other`.
- Accepts the existing `name: value` map (no path → treated as `Path=/`), `name: { value, path }` records, or a previous `res.cookies` array.
- Docs live in `docs/cookies.md` (so I don't pollute a nice readme with extra hunk related to cookies only); the generated `lib/config-validator.js` allows a cookie array as well as an object.

## Test plan
- [x] `npm test` (lint, 100% unit coverage, tstyche)
- [x] Confirm string cookies still go out on every path: `{ session: 'abc' }`
- [x] Confirm a scoped cookie is omitted when the request path does not match
- [x] Confirm a scoped cookie is sent when the request path is a valid RFC 6265 prefix (`/account/123` → `/account/123/settings`, not `/account/other` or `/docsets` vs `/docs`)
- [x] Replay `login.cookies` onto a later `inject` and check only matching cookies appear on `Cookie`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
